### PR TITLE
Do not install dataclasses if already available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pytest==5.2.1
-dataclasses==0.7
+dataclasses==0.7;python_version<"3.7"


### PR DESCRIPTION
The dataclasses package in the requirements.txt is a backport of Python 3.7's dataclasses module for Python 3.6. 

As a result, it's only available for install when Python3.6 is used.

This PR adds an [environment marker](https://www.python.org/dev/peps/pep-0508/#environment-markers) to the requirements.txt so that people using Python3.7 won't see their `pip install -r requirements.txt` fail.