### PR TITLE
add 2 compute plan tests: success + recursive fail

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -29,11 +29,10 @@ class Future:
         key = self._asset.key
         return_statuses = ['done', 'failed']
         while self._asset.status not in return_statuses:
-            print('status:', self._asset.status)
             if time.time() - tstart > timeout:
                 raise errors.TError(f'Future timeout on {self._asset}')
 
-            time.sleep(1)
+            time.sleep(3)
             self._asset = self._getter(key)
         return self.get()
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -29,10 +29,11 @@ class Future:
         key = self._asset.key
         return_statuses = ['done', 'failed']
         while self._asset.status not in return_statuses:
+            print('status:', self._asset.status)
             if time.time() - tstart > timeout:
                 raise errors.TError(f'Future timeout on {self._asset}')
 
-            time.sleep(3)
+            time.sleep(1)
             self._asset = self._getter(key)
         return self.get()
 

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -66,6 +66,8 @@ if __name__ == '__main__':
     tools.algo.execute(TestAlgo())
 """
 
+INVALID_ALGO_SCRIPT = DEFAULT_ALGO_SCRIPT.replace('train', 'naitr')
+
 DEFAULT_METRICS_DOCKERFILE = f"""
 FROM eu.gcr.io/substra-208412/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}
 RUN mkdir -p /sandbox/opener
@@ -215,7 +217,7 @@ class ComputePlanSpec(_Spec):
 
     def add_testtuple(self, traintuple_spec, tag=None):
         spec = ComputePlanTesttupleSpec(
-            traintuple_key=traintuple_spec.traintuple_id,
+            traintuple_id=traintuple_spec.traintuple_id,
             tag=tag or '',
         )
         self.testtuples.append(spec)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -172,8 +172,7 @@ def test_traintuple_execution_failure(factory, session):
     )
     objective = session.add_objective(spec)
 
-    invalid_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace('train', 'naitr')
-    spec = factory.create_algo(py_script=invalid_script)
+    spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = session.add_algo(spec)
 
     spec = factory.create_traintuple(
@@ -185,88 +184,3 @@ def test_traintuple_execution_failure(factory, session):
     traintuple = session.add_traintuple(spec).future().wait()
     assert traintuple.status == 'failed'
     assert traintuple.out_model is None
-
-
-@pytest.mark.skip('may raise MVCC errors')
-def test_compute_plan(factory, session_1, session_2):
-    """Execution of a compute plan containing multiple traintuples:
-    - 1 traintuple executed on node 1
-    - 1 traintuple executed on node 2
-    - 1 traintuple executed on node 1 depending on previous traintuples
-    """
-
-    # TODO create a fixture for initializing network with a set of nodes!
-
-    # add test data samples / dataset / ojective on node 1
-    spec = factory.create_dataset()
-    dataset_1 = session_1.add_dataset(spec)
-
-    spec = factory.create_data_sample(test_only=True, datasets=[dataset_1])
-    test_data_sample_1 = session_1.add_data_sample(spec)
-
-    spec = factory.create_data_sample(test_only=False, datasets=[dataset_1])
-    data_sample_11 = session_1.add_data_sample(spec)
-
-    spec = factory.create_objective(
-        dataset=dataset_1,
-        data_samples=[test_data_sample_1],
-    )
-    objective_1 = session_1.add_objective(spec)
-
-    # refresh dataset_1 as data samples have been added
-    dataset_1 = session_1.get_dataset(dataset_1.key)
-
-    # add train data samples / dataset / algo on node 2
-    spec = factory.create_dataset()
-    dataset_2 = session_2.add_dataset(spec)
-
-    spec = factory.create_data_sample(test_only=False, datasets=[dataset_2])
-    data_sample_21 = session_2.add_data_sample(spec)
-
-    spec = factory.create_algo()
-    algo_2 = session_2.add_algo(spec)
-
-    # refresh dataset_2 as data samples have been added
-    dataset_2 = session_2.get_dataset(dataset_2.key)
-
-    # create compute plan
-    cp_spec = factory.create_compute_plan(algo=algo_2, objective=objective_1)
-
-    # TODO add a testtuple in the compute plan
-
-    traintuple_spec_1 = cp_spec.add_traintuple(
-        dataset=dataset_1,
-        data_samples=[data_sample_11]
-    )
-
-    traintuple_spec_2 = cp_spec.add_traintuple(
-        dataset=dataset_2,
-        data_samples=[data_sample_21]
-    )
-
-    _ = cp_spec.add_traintuple(
-        dataset=dataset_1,
-        data_samples=[data_sample_11],
-        traintuple_specs=[traintuple_spec_1, traintuple_spec_2],
-    )
-
-    # submit compute plan and wait for it to complete
-    cp = session_1.add_compute_plan(cp_spec)
-
-    traintuples = [
-        session_1.get_traintuple(key).future().wait()
-        for key in cp.traintuple_keys
-    ]
-
-    # check all traintuples are done and check they have been executed on the expected
-    # node
-    for t in traintuples:
-        assert t.status == 'done'
-
-    traintuple_1, traintuple_2, traintuple_3 = traintuples
-
-    assert len(traintuple_3.in_models) == 2
-
-    assert traintuple_1.dataset.worker == session_1.node_id
-    assert traintuple_2.dataset.worker == session_2.node_id
-    assert traintuple_3.dataset.worker == session_1.node_id

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -1,0 +1,238 @@
+import substra
+
+import pytest
+
+import substratest as sbt
+
+
+@pytest.mark.skip('may raise MVCC errors')
+def test_compute_plan(factory, session_1, session_2):
+    """Execution of a compute plan containing multiple traintuples:
+    - 1 traintuple executed on node 1
+    - 1 traintuple executed on node 2
+    - 1 traintuple executed on node 1 depending on previous traintuples
+    """
+
+    # TODO create a fixture for initializing network with a set of nodes!
+
+    # add test data samples / dataset / ojective on node 1
+    spec = factory.create_dataset()
+    dataset_1 = session_1.add_dataset(spec)
+
+    spec = factory.create_data_sample(test_only=True, datasets=[dataset_1])
+    test_data_sample_1 = session_1.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset_1])
+    data_sample_11 = session_1.add_data_sample(spec)
+
+    spec = factory.create_objective(
+        dataset=dataset_1,
+        data_samples=[test_data_sample_1],
+    )
+    objective_1 = session_1.add_objective(spec)
+
+    # refresh dataset_1 as data samples have been added
+    dataset_1 = session_1.get_dataset(dataset_1.key)
+
+    # add train data samples / dataset / algo on node 2
+    spec = factory.create_dataset()
+    dataset_2 = session_2.add_dataset(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset_2])
+    data_sample_21 = session_2.add_data_sample(spec)
+
+    spec = factory.create_algo()
+    algo_2 = session_2.add_algo(spec)
+
+    # refresh dataset_2 as data samples have been added
+    dataset_2 = session_2.get_dataset(dataset_2.key)
+
+    # create compute plan
+    cp_spec = factory.create_compute_plan(algo=algo_2, objective=objective_1)
+
+    # TODO add a testtuple in the compute plan
+
+    traintuple_spec_1 = cp_spec.add_traintuple(
+        dataset=dataset_1,
+        data_samples=[data_sample_11]
+    )
+
+    traintuple_spec_2 = cp_spec.add_traintuple(
+        dataset=dataset_2,
+        data_samples=[data_sample_21]
+    )
+
+    _ = cp_spec.add_traintuple(
+        dataset=dataset_1,
+        data_samples=[data_sample_11],
+        traintuple_specs=[traintuple_spec_1, traintuple_spec_2],
+    )
+
+    # submit compute plan and wait for it to complete
+    cp = session_1.add_compute_plan(cp_spec)
+
+    traintuples = [
+        session_1.get_traintuple(key).future().wait()
+        for key in cp.traintuple_keys
+    ]
+
+    # check all traintuples are done and check they have been executed on the expected
+    # node
+    for t in traintuples:
+        assert t.status == 'done'
+
+    traintuple_1, traintuple_2, traintuple_3 = traintuples
+
+    assert len(traintuple_3.in_models) == 2
+
+    assert traintuple_1.dataset.worker == session_1.node_id
+    assert traintuple_2.dataset.worker == session_2.node_id
+    assert traintuple_3.dataset.worker == session_1.node_id
+
+
+def test_compute_plan_single_session_success(factory, session):
+    """A compute plan with 3 traintuples and 3 associated testtuples"""
+
+    # Create a compute plan with 3 steps:
+    #
+    # 1. traintuple + testtuple
+    # 2. traintuple + testtuple
+    # 3. traintuple + testtuple
+
+    spec = factory.create_dataset()
+    dataset = session.add_dataset(spec)
+
+    spec = factory.create_algo()
+    algo = session.add_algo(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset])
+    data_sample_1 = session.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset])
+    data_sample_2 = session.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset])
+    data_sample_3 = session.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=True, datasets=[dataset])
+    test_data_sample_1 = session.add_data_sample(spec)
+
+    spec = factory.create_objective(
+        dataset=dataset,
+        data_samples=[test_data_sample_1],
+    )
+    objective = session.add_objective(spec)
+
+    cp_spec = factory.create_compute_plan(algo=algo, objective=objective)
+
+    traintuple_spec_1 = cp_spec.add_traintuple(
+        dataset=dataset,
+        data_samples=[data_sample_1]
+    )
+    testtuple_spec_1 = cp_spec.add_testtuple(traintuple_spec_1)
+
+    traintuple_spec_2 = cp_spec.add_traintuple(
+        dataset=dataset,
+        data_samples=[data_sample_2],
+        traintuple_specs=[traintuple_spec_1]
+    )
+    testtuple_spec_2 = cp_spec.add_testtuple(traintuple_spec_2)
+
+    traintuple_spec_3 = cp_spec.add_traintuple(
+        dataset=dataset,
+        data_samples=[data_sample_3],
+        traintuple_specs=[traintuple_spec_2]
+    )
+    testtuple_spec_3 = cp_spec.add_testtuple(traintuple_spec_3)
+
+    # Submit compute plan and wait for it to complete
+    cp = session.add_compute_plan(cp_spec)
+
+    traintuples = [
+        session.get_traintuple(key).future().wait()
+        for key in cp.traintuple_keys
+    ]
+
+    testtuples = [
+        session.get_testtuple(key).future().wait()
+        for key in cp.testtuple_keys
+    ]
+
+    # All the train/test tuples should succeed
+    for t in traintuples + testtuples:
+        assert t.status == 'done'
+
+
+def test_compute_plan_single_session_failure(factory, session):
+    """In a compute plan with 3 traintuples, failing the root traintuple should also fail its descendents and the associated testtuples"""
+
+    # Create a compute plan with 3 steps:
+    #
+    # 1. traintuple + testtuple
+    # 2. traintuple + testtuple
+    # 3. traintuple + testtuple
+    #
+    # Intentionally use an invalid (broken) algo.
+
+    spec = factory.create_dataset()
+    dataset = session.add_dataset(spec)
+
+    spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
+    algo = session.add_algo(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset])
+    data_sample_1 = session.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset])
+    data_sample_2 = session.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=False, datasets=[dataset])
+    data_sample_3 = session.add_data_sample(spec)
+
+    spec = factory.create_data_sample(test_only=True, datasets=[dataset])
+    test_data_sample_1 = session.add_data_sample(spec)
+
+    spec = factory.create_objective(
+        dataset=dataset,
+        data_samples=[test_data_sample_1],
+    )
+    objective = session.add_objective(spec)
+
+    cp_spec = factory.create_compute_plan(algo=algo, objective=objective)
+
+    traintuple_spec_1 = cp_spec.add_traintuple(
+        dataset=dataset,
+        data_samples=[data_sample_1]
+    )
+    testtuple_spec_1 = cp_spec.add_testtuple(traintuple_spec_1)
+
+    traintuple_spec_2 = cp_spec.add_traintuple(
+        dataset=dataset,
+        data_samples=[data_sample_2],
+        traintuple_specs=[traintuple_spec_1]
+    )
+    testtuple_spec_2 = cp_spec.add_testtuple(traintuple_spec_2)
+
+    traintuple_spec_3 = cp_spec.add_traintuple(
+        dataset=dataset,
+        data_samples=[data_sample_3],
+        traintuple_specs=[traintuple_spec_2]
+    )
+    testtuple_spec_3 = cp_spec.add_testtuple(traintuple_spec_3)
+
+    # Submit compute plan and wait for it to complete
+    cp = session.add_compute_plan(cp_spec)
+
+    traintuples = [
+        session.get_traintuple(key).future().wait()
+        for key in cp.traintuple_keys
+    ]
+
+    testtuples = [
+        session.get_testtuple(key).future().wait()
+        for key in cp.testtuple_keys
+    ]
+
+    # All the train/test tuples should be marked as failed
+    for t in traintuples + testtuples:
+        assert t.status == 'failed'

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -223,10 +223,26 @@ def test_compute_plan_single_session_failure(factory, session):
     # Submit compute plan and wait for it to complete
     cp = session.add_compute_plan(cp_spec)
 
+    print()
+    print()
+    print()
+    print('WAIT FOR TRAIN 1')
+    traintuple = session.get_traintuple(cp.traintuple_keys[0]).future().wait()
+    print('status:', traintuple.status)
+    print('WAIT FOR TRAIN 2')
+    traintuple = session.get_traintuple(cp.traintuple_keys[1]).future().wait()
+    print('status:', traintuple.status)
+    print('WAIT FOR TRAIN 3')
+    traintuple = session.get_traintuple(cp.traintuple_keys[2]).future().wait()
+    print('status:', traintuple.status)
+    
+
     traintuples = [
         session.get_traintuple(key).future().wait()
         for key in cp.traintuple_keys
     ]
+
+    print('WAIT FOR TEST')
 
     testtuples = [
         session.get_testtuple(key).future().wait()
@@ -234,5 +250,8 @@ def test_compute_plan_single_session_failure(factory, session):
     ]
 
     # All the train/test tuples should be marked as failed
+    for t in traintuples + testtuples:
+        print(t.status)
+
     for t in traintuples + testtuples:
         assert t.status == 'failed'

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -223,26 +223,10 @@ def test_compute_plan_single_session_failure(factory, session):
     # Submit compute plan and wait for it to complete
     cp = session.add_compute_plan(cp_spec)
 
-    print()
-    print()
-    print()
-    print('WAIT FOR TRAIN 1')
-    traintuple = session.get_traintuple(cp.traintuple_keys[0]).future().wait()
-    print('status:', traintuple.status)
-    print('WAIT FOR TRAIN 2')
-    traintuple = session.get_traintuple(cp.traintuple_keys[1]).future().wait()
-    print('status:', traintuple.status)
-    print('WAIT FOR TRAIN 3')
-    traintuple = session.get_traintuple(cp.traintuple_keys[2]).future().wait()
-    print('status:', traintuple.status)
-    
-
     traintuples = [
         session.get_traintuple(key).future().wait()
         for key in cp.traintuple_keys
     ]
-
-    print('WAIT FOR TEST')
 
     testtuples = [
         session.get_testtuple(key).future().wait()
@@ -250,8 +234,5 @@ def test_compute_plan_single_session_failure(factory, session):
     ]
 
     # All the train/test tuples should be marked as failed
-    for t in traintuples + testtuples:
-        print(t.status)
-
     for t in traintuples + testtuples:
         assert t.status == 'failed'

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -1,5 +1,3 @@
-import substra
-
 import pytest
 
 import substratest as sbt
@@ -129,21 +127,21 @@ def test_compute_plan_single_session_success(factory, session):
         dataset=dataset,
         data_samples=[data_sample_1]
     )
-    testtuple_spec_1 = cp_spec.add_testtuple(traintuple_spec_1)
+    cp_spec.add_testtuple(traintuple_spec_1)
 
     traintuple_spec_2 = cp_spec.add_traintuple(
         dataset=dataset,
         data_samples=[data_sample_2],
         traintuple_specs=[traintuple_spec_1]
     )
-    testtuple_spec_2 = cp_spec.add_testtuple(traintuple_spec_2)
+    cp_spec.add_testtuple(traintuple_spec_2)
 
     traintuple_spec_3 = cp_spec.add_traintuple(
         dataset=dataset,
         data_samples=[data_sample_3],
         traintuple_specs=[traintuple_spec_2]
     )
-    testtuple_spec_3 = cp_spec.add_testtuple(traintuple_spec_3)
+    cp_spec.add_testtuple(traintuple_spec_3)
 
     # Submit compute plan and wait for it to complete
     cp = session.add_compute_plan(cp_spec)
@@ -164,7 +162,8 @@ def test_compute_plan_single_session_success(factory, session):
 
 
 def test_compute_plan_single_session_failure(factory, session):
-    """In a compute plan with 3 traintuples, failing the root traintuple should also fail its descendents and the associated testtuples"""
+    """In a compute plan with 3 traintuples, failing the root traintuple should also
+    fail its descendents and the associated testtuples"""
 
     # Create a compute plan with 3 steps:
     #
@@ -204,21 +203,21 @@ def test_compute_plan_single_session_failure(factory, session):
         dataset=dataset,
         data_samples=[data_sample_1]
     )
-    testtuple_spec_1 = cp_spec.add_testtuple(traintuple_spec_1)
+    cp_spec.add_testtuple(traintuple_spec_1)
 
     traintuple_spec_2 = cp_spec.add_traintuple(
         dataset=dataset,
         data_samples=[data_sample_2],
         traintuple_specs=[traintuple_spec_1]
     )
-    testtuple_spec_2 = cp_spec.add_testtuple(traintuple_spec_2)
+    cp_spec.add_testtuple(traintuple_spec_2)
 
     traintuple_spec_3 = cp_spec.add_traintuple(
         dataset=dataset,
         data_samples=[data_sample_3],
         traintuple_specs=[traintuple_spec_2]
     )
-    testtuple_spec_3 = cp_spec.add_testtuple(traintuple_spec_3)
+    cp_spec.add_testtuple(traintuple_spec_3)
 
     # Submit compute plan and wait for it to complete
     cp = session.add_compute_plan(cp_spec)


### PR DESCRIPTION
See [Chaincode PR](https://github.com/SubstraFoundation/substra-chaincode/pull/2)

--

This PR bundles several changes:

1. **Fix**: The `traintuple_id` parameter in the `ComputePlanTesttupleSpec`
2. **Refactor**: Create the `INVALID_ALGO_SCRIPT` constant, so that it can be reused accross tests
3. **Refactor**: Move the existing compute plan test to a new file `test_execution_compute_plan.py`
4. **Add new tests**: 
   - Compute plan success (single node)
   - Compute plan failure (single node)

Note that these new tests each take about 10 seconds to run on my machine. So this increases the total test run time (`make test`) by ~20 secs.