### PR TITLE
Remove manual docker pull of substra-tools and update image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,6 @@ pip3 install -r requirements.txt
 The tests suite requires a Substra network up and running. The network can be started
 either with skaffold (Kubernetes), with docker-compose, or manually.
 
-Make sure you have pulled the different substra-tools images:
-```
-$> docker pull eu.gcr.io/substra-208412/substra-tools:0.0.1
-$> docker pull eu.gcr.io/substra-208412/substra-tools:0.1.0
-$> docker pull eu.gcr.io/substra-208412/substra-tools:0.2.0
-```
-
 The substra project is needed for running the tests.  
 It can be found [here](https://github.com/SubstraFoundation/substra)
 

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
 INVALID_ALGO_SCRIPT = DEFAULT_ALGO_SCRIPT.replace('train', 'naitr')
 
 DEFAULT_METRICS_DOCKERFILE = f"""
-FROM eu.gcr.io/substra-208412/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}
+FROM substrafoundation/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}
 RUN mkdir -p /sandbox/opener
 WORKDIR /sandbox
 COPY metrics.py .
@@ -77,7 +77,7 @@ ENTRYPOINT ["python3", "metrics.py"]
 """
 
 DEFAULT_ALGO_DOCKERFILE = f"""
-FROM eu.gcr.io/substra-208412/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}
+FROM substrafoundation/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}
 RUN mkdir -p /sandbox/opener
 WORKDIR /sandbox
 COPY algo.py .


### PR DESCRIPTION
As substra-tools is now on docker hub we don't need to pull it manually anymore !