### PR TITLE
Fix local shared path in docker-compose context.

### DIFF
--- a/local-values.yaml
+++ b/local-values.yaml
@@ -4,10 +4,10 @@ nodes:
     address: 'http://substra-backend.owkin.xyz:8000'
     user: 'substra'
     password: 'p@$swr0d44'
-    shared_path: '/tmp/substra'  # needs to match SUBSTRA_PATH
+    shared_path: '/tmp/substra/servermedias'  # needs to match ${SUBSTRA_PATH}/servermedias
   - name: 'chunantes'
     msp_id: 'chu-nantesMSP'
     address: 'http://substra-backend.chunantes.xyz:8001'
     user: 'substra'
     password: 'p@$swr0d45'
-    shared_path: '/tmp/substra'  # needs to match SUBSTRA_PATH
+    shared_path: '/tmp/substra/servermedias'  # needs to match ${SUBSTRA_PATH}/servermedias


### PR DESCRIPTION
Local shared path was not well set in case of docker-compose setup.
@GuillaumeCisco Can you tell me if this modification will be an issue in the case of a local setup ? I don't think so as the backend in local setup will have access to `${SUBSTRA_PATH}/servermedias` !