### PR TITLE
Generic compute plan

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -61,29 +61,25 @@ class Future(BaseFuture):
 
 
 class ComputePlanFuture(BaseFuture):
-    def __init__(self, asset, session):
-        self._asset = asset
-        self._getter = session.get_compute_plan
-        self._get_traintuple = session.get_traintuple
-        self._get_composite_traintuple = session.get_composite_traintuple
-        self._get_aggregatetuple = session.get_aggregatetuple
-        self._get_testtuple = session.get_testtuple
+    def __init__(self, compute_plan, session):
+        self._compute_plan = compute_plan
+        self._session = session
 
     def wait(self, timeout=FUTURE_TIMEOUT):
         """wait until all tuples are completed (done or failed)."""
-        for key in self._asset.traintuple_keys:
-            self._get_traintuple(key).future().wait(timeout, raises=False)
-        for key in self._asset.composite_traintuple_keys:
-            self._get_composite_traintuple(key).future().wait(timeout, raises=False)
-        for key in self._asset.aggregatetuple_keys:
-            self._get_aggregatetuple(key).future().wait(timeout, raises=False)
-        for key in self._asset.testtuple_keys:
-            self._get_testtuple(key).future().wait(timeout, raises=False)
+        for key in self._compute_plan.traintuple_keys:
+            self._session.get_traintuple(key).future().wait(timeout, raises=False)
+        for key in self._compute_plan.composite_traintuple_keys:
+            self._session.get_composite_traintuple(key).future().wait(timeout, raises=False)
+        for key in self._compute_plan.aggregatetuple_keys:
+            self._session.get_aggregatetuple(key).future().wait(timeout, raises=False)
+        for key in self._compute_plan.testtuple_keys:
+            self._session.get_testtuple(key).future().wait(timeout, raises=False)
 
         return self.get()
 
     def get(self):
-        return self._getter(self._asset.compute_plan_id)
+        return self._session.get_compute_plan(self._compute_plan.compute_plan_id)
 
 
 class _BaseFutureMixin(abc.ABC):

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -74,8 +74,8 @@ class ComputePlanFuture(BaseFuture):
         # testtuples do not have a rank attribute
         tuples += self._compute_plan.list_testtuple(self._session)
 
-        for tuple in tuples:
-            tuple.future().wait(timeout, raises=False)
+        for tuple_ in tuples:
+            tuple_.future().wait(timeout, raises=False)
 
         return self.get()
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -363,7 +363,7 @@ class Testtuple(_Asset, _FutureMixin):
 
 
 @dataclasses.dataclass
-class ComputePlanCreated(_Asset, _FutureMixin):
+class ComputePlanCreated(_Asset, _ComputePlanFutureMixin):
     compute_plan_id: str
     traintuple_keys: typing.List[str]
     composite_traintuple_keys: typing.List[str]
@@ -372,7 +372,7 @@ class ComputePlanCreated(_Asset, _FutureMixin):
 
 
 @dataclasses.dataclass
-class ComputePlan(_Asset):
+class ComputePlan(_Asset, _ComputePlanFutureMixin):
     compute_plan_id: str
     objective_key: str
     traintuples: typing.List[str]

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -83,7 +83,7 @@ class ComputePlanFuture(BaseFuture):
         return self.get()
 
     def get(self):
-        return self._getter(self._asset.key)
+        return self._getter(self._asset.compute_plan_id)
 
 
 class _BaseFutureMixin(abc.ABC):
@@ -383,22 +383,28 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
     testtuple_keys: typing.List[str]
 
     def __post_init__(self):
+        if self.composite_traintuple_keys is None:
+            self.composite_traintuple_keys = []
+
+        if self.aggregatetuple_keys is None:
+            self.aggregatetuple_keys = []
+
         if self.testtuple_keys is None:
             self.testtuple_keys = []
 
-    def list_traintuples(self, session):
-        return session.list_traintuples(filters=[f'traintuple:computePlanId:{self.compute_plan_id}'])
+    def list_traintuple(self, session):
+        return session.list_traintuple(filters=[f'traintuple:computePlanId:{self.compute_plan_id}'])
 
-    def list_composite_traintuples(self, session):
-        return session.list_composite_traintuples(
+    def list_composite_traintuple(self, session):
+        return session.list_composite_traintuple(
             filters=[f'composite_traintuple:computePlanId:{self.compute_plan_id}']
         )
 
-    def list_aggregatetuples(self, session):
-        return session.list_aggregatetuples(filters=[f'aggregatetuple:computePlanId:{self.compute_plan_id}'])
+    def list_aggregatetuple(self, session):
+        return session.list_aggregatetuple(filters=[f'aggregatetuple:computePlanId:{self.compute_plan_id}'])
 
-    def list_testtuples(self, session):
-        return session.list_testtuples(filters=[f'testtuple:computePlanId:{self.compute_plan_id}'])
+    def list_testtuple(self, session):
+        return session.list_testtuple(filters=[f'testtuple:computePlanId:{self.compute_plan_id}'])
 
 
 @dataclasses.dataclass(frozen=True)

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -146,7 +146,7 @@ class Session:
 
     def add_compute_plan(self, spec):
         res = self._client.add_compute_plan(spec.to_dict())
-        compute_plan = assets.ComputePlanCreated.load(res).attach(self)
+        compute_plan = assets.ComputePlan.load(res).attach(self)
         self.state.compute_plans.append(compute_plan)
         return compute_plan
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -156,7 +156,7 @@ class Session:
 
     def get_compute_plan(self, *args, **kwargs):
         res = self._client.get_compute_plan(*args, **kwargs)
-        compute_plan = assets.ComputePlan.load(res)
+        compute_plan = assets.ComputePlan.load(res).attach(self)
         self.state.update_compute_plan(compute_plan)
         return compute_plan
 
@@ -214,7 +214,7 @@ class Session:
 
     def list_traintuple(self, *args, **kwargs):
         res = self._client.list_traintuple(*args, **kwargs)
-        return [assets.Traintuple.load(x) for x in res]
+        return [assets.Traintuple.load(x).attach(self) for x in res]
 
     def get_aggregatetuple(self, *args, **kwargs):
         res = self._client.get_aggregatetuple(*args, **kwargs)
@@ -224,7 +224,7 @@ class Session:
 
     def list_aggregatetuple(self, *args, **kwargs):
         res = self._client.list_aggregatetuple(*args, **kwargs)
-        return [assets.Aggregatetuple.load(x) for x in res]
+        return [assets.Aggregatetuple.load(x).attach(self) for x in res]
 
     def get_composite_traintuple(self, *args, **kwargs):
         res = self._client.get_composite_traintuple(*args, **kwargs)
@@ -234,7 +234,7 @@ class Session:
 
     def list_composite_traintuple(self, *args, **kwargs):
         res = self._client.list_composite_traintuple(*args, **kwargs)
-        return [assets.CompositeTraintuple.load(x) for x in res]
+        return [assets.CompositeTraintuple.load(x).attach(self) for x in res]
 
     def get_testtuple(self, *args, **kwargs):
         res = self._client.get_testtuple(*args, **kwargs)
@@ -244,7 +244,7 @@ class Session:
 
     def list_testtuple(self, *args, **kwargs):
         res = self._client.list_testtuple(*args, **kwargs)
-        return [assets.Testtuple.load(x) for x in res]
+        return [assets.Testtuple.load(x).attach(self) for x in res]
 
     def list_node(self, *args, **kwargs):
         res = self._client.list_node(*args, **kwargs)

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -146,7 +146,7 @@ class Session:
 
     def add_compute_plan(self, spec):
         res = self._client.add_compute_plan(spec.to_dict())
-        compute_plan = assets.ComputePlanCreated.load(res)
+        compute_plan = assets.ComputePlanCreated.load(res).attach(self)
         self.state.compute_plans.append(compute_plan)
         return compute_plan
 

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -347,14 +347,14 @@ class ComputePlanSpec(_Spec):
         return spec
 
     def add_composite_traintuple(self, composite_algo, dataset=None, data_samples=None,
-                                 in_head_model_tuple=None, in_trunk_model_tuple=None,
+                                 in_head_model=None, in_trunk_model=None,
                                  out_trunk_model_permissions=None, tag=''):
         data_samples = data_samples or []
 
-        if in_head_model_tuple and in_trunk_model_tuple:
-            assert isinstance(in_head_model_tuple, ComputePlanCompositeTraintupleSpec)
+        if in_head_model and in_trunk_model:
+            assert isinstance(in_head_model, ComputePlanCompositeTraintupleSpec)
             assert isinstance(
-                in_trunk_model_tuple,
+                in_trunk_model,
                 (ComputePlanCompositeTraintupleSpec, ComputePlanAggregatetupleSpec)
             )
 
@@ -363,8 +363,8 @@ class ComputePlanSpec(_Spec):
             algo_key=composite_algo.key,
             data_manager_key=dataset.key if dataset else None,
             train_data_sample_keys=_get_keys(data_samples),
-            in_head_model_id=in_head_model_tuple.id if in_head_model_tuple else None,
-            in_trunk_model_id=in_trunk_model_tuple.id if in_trunk_model_tuple else None,
+            in_head_model_id=in_head_model.id if in_head_model else None,
+            in_trunk_model_id=in_trunk_model.id if in_trunk_model else None,
             out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_MODEL_PERMISSIONS,
             tag=tag,
         )

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -317,30 +317,30 @@ class ComputePlanSpec(_Spec):
     aggregatetuples: typing.List[ComputePlanAggregatetupleSpec]
     testtuples: typing.List[ComputePlanTesttupleSpec]
 
-    def add_traintuple(self, algo, dataset, data_samples, in_models_tuples=None, tag=''):
-        in_models_tuples = in_models_tuples or []
+    def add_traintuple(self, algo, dataset, data_samples, in_models=None, tag=''):
+        in_models = in_models or []
         spec = ComputePlanTraintupleSpec(
             algo_key=algo.key,
             traintuple_id=random_uuid(),
             data_manager_key=dataset.key,
             train_data_sample_keys=_get_keys(data_samples),
-            in_models_ids=[t.id for t in in_models_tuples],
+            in_models_ids=[t.id for t in in_models],
             tag=tag,
         )
         self.traintuples.append(spec)
         return spec
 
-    def add_aggregatetuple(self, aggregate_algo, worker, in_models_tuples=None, tag=''):
-        in_models_tuples = in_models_tuples or []
+    def add_aggregatetuple(self, aggregate_algo, worker, in_models=None, tag=''):
+        in_models = in_models or []
 
-        for t in in_models_tuples:
+        for t in in_models:
             assert isinstance(t, (ComputePlanTraintupleSpec, ComputePlanCompositeTraintupleSpec))
 
         spec = ComputePlanAggregatetupleSpec(
             aggregatetuple_id=random_uuid(),
             algo_key=aggregate_algo.key,
             worker=worker,
-            in_models_ids=[t.id for t in in_models_tuples],
+            in_models_ids=[t.id for t in in_models],
             tag=tag,
         )
         self.aggregatetuples.append(spec)

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -142,6 +142,7 @@ class Permissions:
 
 
 DEFAULT_PERMISSIONS = Permissions(public=True, authorized_ids=[])
+DEFAULT_OUT_MODEL_PERMISSIONS = Permissions(public=False, authorized_ids=[])
 
 
 @dataclasses.dataclass
@@ -243,11 +244,45 @@ class TesttupleSpec(_Spec):
 
 @dataclasses.dataclass
 class ComputePlanTraintupleSpec:
+    algo_key: str
     data_manager_key: str
     train_data_sample_keys: str
     traintuple_id: str
     in_models_ids: typing.List[str]
     tag: str
+
+    @property
+    def id(self):
+        return self.traintuple_id
+
+
+@dataclasses.dataclass
+class ComputePlanAggregatetupleSpec(_Spec):
+    aggregatetuple_id: str
+    algo_key: str
+    worker: str
+    in_models_ids: typing.List[str]
+    tag: str
+
+    @property
+    def id(self):
+        return self.aggregatetuple_id
+
+
+@dataclasses.dataclass
+class ComputePlanCompositeTraintupleSpec(_Spec):
+    composite_traintuple_id: str
+    algo_key: str
+    data_manager_key: str
+    train_data_sample_keys: str
+    in_head_model_id: str
+    in_trunk_model_id: str
+    tag: str
+    out_trunk_model_permissions: typing.Dict
+
+    @property
+    def id(self):
+        return self.composite_traintuple_id
 
 
 @dataclasses.dataclass
@@ -276,26 +311,69 @@ def _get_keys(obj, field='key'):
 
 @dataclasses.dataclass
 class ComputePlanSpec(_Spec):
-    algo_key: str
     objective_key: str
     traintuples: typing.List[ComputePlanTraintupleSpec]
+    composite_traintuples: typing.List[ComputePlanCompositeTraintupleSpec]
+    aggregatetuples: typing.List[ComputePlanAggregatetupleSpec]
     testtuples: typing.List[ComputePlanTesttupleSpec]
 
-    def add_traintuple(self, dataset, data_samples, traintuple_specs=None, tag=None):
-        traintuple_specs = traintuple_specs or []
+    def add_traintuple(self, algo, dataset, data_samples, in_models_tuples=None, tag=''):
+        in_models_tuples = in_models_tuples or []
         spec = ComputePlanTraintupleSpec(
+            algo_key=algo.key,
             traintuple_id=random_uuid(),
             data_manager_key=dataset.key,
             train_data_sample_keys=_get_keys(data_samples),
-            in_models_ids=[t.traintuple_id for t in traintuple_specs],
-            tag=tag or '',
+            in_models_ids=[t.id for t in in_models_tuples],
+            tag=tag,
         )
         self.traintuples.append(spec)
         return spec
 
+    def add_aggregatetuple(self, aggregate_algo, worker, in_models_tuples=None, tag=''):
+        in_models_tuples = in_models_tuples or []
+
+        for t in in_models_tuples:
+            assert isinstance(t, (ComputePlanTraintupleSpec, ComputePlanCompositeTraintupleSpec))
+
+        spec = ComputePlanAggregatetupleSpec(
+            aggregatetuple_id=random_uuid(),
+            algo_key=aggregate_algo.key,
+            worker=worker,
+            in_models_ids=[t.id for t in in_models_tuples],
+            tag=tag,
+        )
+        self.aggregatetuples.append(spec)
+        return spec
+
+    def add_composite_traintuple(self, composite_algo, dataset=None, data_samples=None,
+                                 in_head_model_tuple=None, in_trunk_model_tuple=None,
+                                 out_trunk_model_permissions=None, tag=''):
+        data_samples = data_samples or []
+
+        if in_head_model_tuple and in_trunk_model_tuple:
+            assert isinstance(in_head_model_tuple, ComputePlanCompositeTraintupleSpec)
+            assert isinstance(
+                in_trunk_model_tuple,
+                (ComputePlanCompositeTraintupleSpec, ComputePlanAggregatetupleSpec)
+            )
+
+        spec = ComputePlanCompositeTraintupleSpec(
+            composite_traintuple_id=random_uuid(),
+            algo_key=composite_algo.key,
+            data_manager_key=dataset.key if dataset else None,
+            train_data_sample_keys=_get_keys(data_samples),
+            in_head_model_id=in_head_model_tuple.id if in_head_model_tuple else None,
+            in_trunk_model_id=in_trunk_model_tuple.id if in_trunk_model_tuple else None,
+            out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_MODEL_PERMISSIONS,
+            tag=tag,
+        )
+        self.composite_traintuples.append(spec)
+        return spec
+
     def add_testtuple(self, traintuple_spec, tag=None):
         spec = ComputePlanTesttupleSpec(
-            traintuple_id=traintuple_spec.traintuple_id,
+            traintuple_id=traintuple_spec.id,
             tag=tag or '',
         )
         self.testtuples.append(spec)
@@ -486,8 +564,6 @@ class AssetsFactory:
                                     permissions=None):
         data_samples = data_samples or []
 
-        kwargs = {}
-
         if head_traintuple and trunk_traintuple:
             assert isinstance(head_traintuple, assets.CompositeTraintuple)
             assert isinstance(
@@ -511,7 +587,6 @@ class AssetsFactory:
             compute_plan_id=compute_plan_id,
             rank=rank,
             out_trunk_model_permissions=permissions or DEFAULT_PERMISSIONS,
-            **kwargs,
         )
 
     def create_testtuple(self, traintuple=None, tag=None):
@@ -520,10 +595,11 @@ class AssetsFactory:
             tag=tag,
         )
 
-    def create_compute_plan(self, algo=None, objective=None):
+    def create_compute_plan(self, objective=None):
         return ComputePlanSpec(
-            algo_key=algo.key if algo else None,
             objective_key=objective.key if objective else None,
             traintuples=[],
+            composite_traintuples=[],
+            aggregatetuples=[],
             testtuples=[],
         )

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -279,4 +279,4 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
     with pytest.raises(substra.exceptions.InvalidRequest) as e:
         session.add_compute_plan(cp_spec)
 
-    assert 'circular' in str(e)
+    assert 'missing dependency among inModels IDs' in str(e)

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -236,9 +236,9 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
         )
 
     cp = sessions[0].add_compute_plan(cp_spec).future().wait()
-    tuples = (cp.list_traintuple(sessions) +
+    tuples = (cp.list_traintuple(sessions[0]) +
               cp.list_composite_traintuple(sessions[0]) +
-              cp.list_aggregate_tuple(sessions[0]) +
+              cp.list_aggregatetuple(sessions[0]) +
               cp.list_testtuple(sessions[0]))
     for t in tuples:
         assert t.status == 'done'
@@ -274,4 +274,4 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
     with pytest.raises(substra.exceptions.InvalidRequest) as e:
         session.add_compute_plan(cp_spec)
 
-    assert 'missing dependency among inModels IDs' in str(e)
+    assert 'missing dependency among inModels IDs' in str(e.value)

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -217,8 +217,8 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
             kwargs = {}
             if previous_aggregatetuple_spec:
                 kwargs = {
-                    'in_head_model_tuple': previous_composite_traintuple_specs[index],
-                    'in_trunk_model_tuple': previous_aggregatetuple_spec,
+                    'in_head_model': previous_composite_traintuple_specs[index],
+                    'in_trunk_model': previous_aggregatetuple_spec,
                 }
             spec = cp_spec.add_composite_traintuple(
                 composite_algo=composite_algo,

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -48,7 +48,7 @@ def test_compute_plan(global_execution_env):
     # submit compute plan and wait for it to complete
     cp = session_1.add_compute_plan(cp_spec).future().wait()
 
-    traintuples = cp.list_traintuples(session_1)
+    traintuples = cp.list_traintuple(session_1)
 
     # check all traintuples are done and check they have been executed on the expected
     # node
@@ -112,13 +112,8 @@ def test_compute_plan_single_session_success(global_execution_env):
     cp = session.add_compute_plan(cp_spec).future().wait()
 
     # All the train/test tuples should succeed
-    for t in cp.list_traintuples(session) + cp.list_testtuples(session):
+    for t in cp.list_traintuple(session) + cp.list_testtuple(session):
         assert t.status == 'done'
-
-    compute_plan = session.get_compute_plan(cp.compute_plan_id)
-    assert cp.compute_plan_id == compute_plan.compute_plan_id
-    assert set(cp.traintuple_keys) == set(compute_plan.traintuples)
-    assert set(cp.testtuple_keys) == set(compute_plan.testtuples)
 
 
 def test_compute_plan_single_session_failure(global_execution_env):
@@ -171,8 +166,8 @@ def test_compute_plan_single_session_failure(global_execution_env):
     # Submit compute plan and wait for it to complete
     cp = session.add_compute_plan(cp_spec).future().wait()
 
-    traintuples = cp.list_traintuples(session)
-    testtuples = cp.list_testtuples(session)
+    traintuples = cp.list_traintuple(session)
+    testtuples = cp.list_testtuple(session)
 
     # All the train/test tuples should be marked as failed
     for t in traintuples + testtuples:
@@ -242,9 +237,9 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
 
     cp = sessions[0].add_compute_plan(cp_spec).future().wait()
     tuples = (cp.list_traintuple(sessions) +
-              cp.list_composite_traintuples(sessions[0]) +
-              cp.list_aggregate_tuples(sessions[0]) +
-              cp.list_testtuples(sessions[0]))
+              cp.list_composite_traintuple(sessions[0]) +
+              cp.list_aggregate_tuple(sessions[0]) +
+              cp.list_testtuple(sessions[0]))
     for t in tuples:
         assert t.status == 'done'
 

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -169,8 +169,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
     cp_spec.add_testtuple(traintuple_spec_3)
 
     # Submit compute plan and wait for it to complete
-    cp_created = session.add_compute_plan(cp_spec)
-    cp = cp_created.future().wait()
+    cp = session.add_compute_plan(cp_spec).future().wait()
 
     traintuples = cp.list_traintuples(session)
     testtuples = cp.list_testtuples(session)
@@ -178,10 +177,6 @@ def test_compute_plan_single_session_failure(global_execution_env):
     # All the train/test tuples should be marked as failed
     for t in traintuples + testtuples:
         assert t.status == 'failed'
-
-    assert cp_created.compute_plan_id == cp.compute_plan_id
-    assert set(cp_created.traintuple_keys) == set(cp.traintuples)
-    assert set(cp_created.testtuple_keys) == set(cp.testtuples)
 
 
 def test_compute_plan_aggregate_composite_traintuples(global_execution_env):


### PR DESCRIPTION
Add 2 tests for generic compute plans:
* make sure circular dependencies are handled correctly
* duplicate the `test_aggregate_composite_traintuples` in a compute plan

This required to update `factory.py` quite a bit.

