### PR TITLE
Use data_network for execution tests

### DIFF
--- a/substratest/client.py
+++ b/substratest/client.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import copy
 
 import substra
 
@@ -45,6 +46,9 @@ class Session:
         self._client = substra.Client()
         self._client.add_profile(node_name, user, password, address, '0.0')
         self._client.login()
+
+    def copy(self):
+        return copy.deepcopy(self)
 
     def add_data_sample(self, spec, *args, **kwargs):
         res = self._client.add_data_sample(spec.to_dict(), *args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,10 @@ def data_network():
             spec = f.create_data_sample(datasets=[dataset], test_only=True)
             test_data_sample = sess.add_data_sample(spec)
 
+            # reload datasets (to ensure they are properly linked with the created data samples)
+            dataset = sess.get_dataset(dataset.key)
+            sess.state.datasets = [dataset]
+
             # create objective
             spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
             sess.add_objective(spec)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,8 +62,8 @@ def network():
     return _get_network()
 
 
-@pytest.yield_fixture(scope='session')
-def data_network():
+@pytest.fixture(scope='session')
+def global_execution_env():
     """Network fixture with pre-existing assets in all nodes.
 
     The following asssets will be created for each node:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def network():
     return _get_network()
 
 
-@pytest.fixture(scope='session')
+@pytest.yield_fixture(scope='session')
 def data_network():
     """Network fixture with pre-existing assets in all nodes.
 
@@ -84,22 +84,22 @@ def data_network():
 
             # create dataset
             spec = f.create_dataset()
-            sess.add_dataset(spec)
+            dataset = sess.add_dataset(spec)
 
             # create train data samples
             for i in range(4):
-                spec = f.create_data_sample(test_only=False).fill_from_session(sess)
+                spec = f.create_data_sample(datasets=[dataset], test_only=False)
                 sess.add_data_sample(spec)
 
             # create test data sample
-            spec = f.create_data_sample(test_only=True).fill_from_session(sess)
-            sess.add_data_sample(spec)
+            spec = f.create_data_sample(datasets=[dataset], test_only=True)
+            test_data_sample = sess.add_data_sample(spec)
 
             # create objective
-            spec = f.create_objective().fill_from_session(sess)
+            spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
             sess.add_objective(spec)
 
-        return f, n
+        yield f, n
 
 
 @pytest.fixture

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,15 +1,14 @@
 import pytest
-import copy
 
 import substra
 
 import substratest as sbt
 
 
-def test_tuples_execution_on_same_node(data_network):
+def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     dataset = session.state.datasets[0]
     objective = session.state.objectives[0]
@@ -47,10 +46,10 @@ def test_tuples_execution_on_same_node(data_network):
     assert len(traintuple.in_models) == 1
 
 
-def test_federated_learning_workflow(data_network):
+def test_federated_learning_workflow(global_execution_env):
     """Test federated learning workflow."""
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     # get test environment
     dataset = session.state.datasets[0]
@@ -98,11 +97,12 @@ def test_federated_learning_workflow(data_network):
         session.add_traintuple(spec)
 
 
-def test_tuples_execution_on_different_nodes(data_network):
+def test_tuples_execution_on_different_nodes(global_execution_env):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / ojective on node 1
-    factory, network = data_network
-    session_1, session_2 = copy.deepcopy(network.sessions)
+    factory, network = global_execution_env
+    session_1 = network.sessions[0].copy()
+    session_2 = network.sessions[1].copy()
 
     objective_1 = session_1.state.objectives[0]
     dataset_2 = session_2.state.datasets[0]
@@ -129,10 +129,10 @@ def test_tuples_execution_on_different_nodes(data_network):
     assert testtuple.dataset.worker == session_1.node_id
 
 
-def test_traintuple_execution_failure(data_network):
+def test_traintuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     objective = session.state.objectives[0]
     dataset = session.state.datasets[0]
@@ -151,11 +151,11 @@ def test_traintuple_execution_failure(data_network):
     assert traintuple.out_model is None
 
 
-def test_composite_traintuples_execution(data_network):
+def test_composite_traintuples_execution(global_execution_env):
     """Execution of composite traintuples."""
 
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     dataset = session.state.datasets[0]
     objective = session.state.objectives[0]
@@ -204,13 +204,13 @@ def test_composite_traintuples_execution(data_network):
     )
 
 
-def test_aggregatetuple(data_network):
+def test_aggregatetuple(global_execution_env):
     """Execution of aggregatetuple aggregating traintuples."""
 
     number_of_traintuples_to_aggregate = 3
 
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     dataset = session.state.datasets[0]
     objective = session.state.objectives[0]
@@ -245,7 +245,7 @@ def test_aggregatetuple(data_network):
     assert len(aggregatetuple.in_models) == number_of_traintuples_to_aggregate
 
 
-def test_aggregate_composite_traintuples(data_network):
+def test_aggregate_composite_traintuples(global_execution_env):
     """Do 2 rounds of composite traintuples aggregations on multiple nodes.
 
     Compute plan details:
@@ -268,8 +268,8 @@ def test_aggregate_composite_traintuples(data_network):
 
     This test refers to the model composition use case.
     """
-    factory, network = data_network
-    sessions = copy.deepcopy(network.sessions)
+    factory, network = global_execution_env
+    sessions = [s.copy() for s in network.sessions]
 
     aggregate_worker = sessions[0].node_id
     number_of_rounds = 2

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -1,18 +1,18 @@
 import pytest
-import copy
 
 import substratest as sbt
 
 
 @pytest.mark.skip('may raise MVCC errors')
-def test_compute_plan(data_network):
+def test_compute_plan(global_execution_env):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
     - 1 traintuple executed on node 2
     - 1 traintuple executed on node 1 depending on previous traintuples
     """
-    factory, network = data_network
-    session_1, session_2 = copy.deepcopy(data_network.sessions)
+    factory, network = global_execution_env
+    session_1 = network.sessions[0].copy()
+    session_2 = network.sessions[1].copy()
 
     dataset_1 = session_1.state.datasets[0]
     dataset_2 = session_2.state.datasets[0]
@@ -64,7 +64,7 @@ def test_compute_plan(data_network):
     assert traintuple_3.dataset.worker == session_1.node_id
 
 
-def test_compute_plan_single_session_success(data_network):
+def test_compute_plan_single_session_success(global_execution_env):
     """A compute plan with 3 traintuples and 3 associated testtuples"""
 
     # Create a compute plan with 3 steps:
@@ -73,8 +73,8 @@ def test_compute_plan_single_session_success(data_network):
     # 2. traintuple + testtuple
     # 3. traintuple + testtuple
 
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     dataset = session.state.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
@@ -128,7 +128,7 @@ def test_compute_plan_single_session_success(data_network):
     assert set(cp.testtuple_keys) == set(compute_plan.testtuples)
 
 
-def test_compute_plan_single_session_failure(data_network):
+def test_compute_plan_single_session_failure(global_execution_env):
     """In a compute plan with 3 traintuples, failing the root traintuple should also
     fail its descendents and the associated testtuples"""
 
@@ -140,8 +140,8 @@ def test_compute_plan_single_session_failure(data_network):
     #
     # Intentionally use an invalid (broken) algo.
 
-    factory, network = data_network
-    session = copy.deepcopy(network.sessions[0])
+    factory, network = global_execution_env
+    session = network.sessions[0].copy()
 
     dataset = session.state.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 
 import substratest as sbt
 
@@ -11,13 +12,11 @@ def test_compute_plan(data_network):
     - 1 traintuple executed on node 1 depending on previous traintuples
     """
     factory, network = data_network
-    session_1, session_2 = data_network.sessions
+    session_1, session_2 = copy.deepcopy(data_network.sessions)
 
     dataset_1 = session_1.state.datasets[0]
     dataset_2 = session_2.state.datasets[0]
     objective_1 = session_1.state.objective[0]
-    train_data_samples_1 = session_1.state.train_data_samples
-    train_data_samples_2 = session_2.state.train_data_samples
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)
@@ -29,17 +28,17 @@ def test_compute_plan(data_network):
 
     traintuple_spec_1 = cp_spec.add_traintuple(
         dataset=dataset_1,
-        data_samples=train_data_samples_1,
+        data_samples=dataset_1.train_data_sample_keys,
     )
 
     traintuple_spec_2 = cp_spec.add_traintuple(
         dataset=dataset_2,
-        data_samples=train_data_samples_2,
+        data_samples=dataset_2.train_data_sample_keys,
     )
 
     _ = cp_spec.add_traintuple(
         dataset=dataset_1,
-        data_samples=train_data_samples_1,
+        data_samples=dataset_1.train_data_sample_keys,
         traintuple_specs=[traintuple_spec_1, traintuple_spec_2],
     )
 
@@ -75,10 +74,10 @@ def test_compute_plan_single_session_success(data_network):
     # 3. traintuple + testtuple
 
     factory, network = data_network
-    session = network.sessions[0]
+    session = copy.deepcopy(network.sessions[0])
 
     dataset = session.state.datasets[0]
-    data_sample_1, data_sample_2, data_sample_3, _ = session.state.train_data_samples
+    data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
     objective = session.state.objectives[0]
 
     spec = factory.create_algo()
@@ -142,10 +141,10 @@ def test_compute_plan_single_session_failure(data_network):
     # Intentionally use an invalid (broken) algo.
 
     factory, network = data_network
-    session = network.sessions[0]
+    session = copy.deepcopy(network.sessions[0])
 
     dataset = session.state.datasets[0]
-    data_sample_1, data_sample_2, data_sample_3, _ = session.state.train_data_samples
+    data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
     objective = session.state.objectives[0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)


### PR DESCRIPTION
Since all execution tests rely on a very similar setup, we can use the existing (but dormant) `data_network` fixture so that base assets (datasets, data samples and objectives) are created only once.