### PR TITLE
Avoid using strings to define tuple status

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -21,12 +21,12 @@ class BaseFuture(abc.ABC):
         raise NotImplementedError
 
 
-class TupleStatus(enum.Enum):
-    doing = enum.auto()
-    done = enum.auto()
-    failed = enum.auto()
-    todo = enum.auto()
-    waiting = enum.auto()
+class TupleStatus:
+    doing = 'doing'
+    done = 'done'
+    failed = 'failed'
+    todo = 'todo'
+    waiting = 'waiting'
 
 
 class Future(BaseFuture):
@@ -51,14 +51,14 @@ class Future(BaseFuture):
         """Wait until completed (done or failed)."""
         tstart = time.time()
         key = self._asset.key
-        while self._asset.status not in [TupleStatus.done.name, TupleStatus.failed.name]:
+        while self._asset.status not in [TupleStatus.done, TupleStatus.failed]:
             if time.time() - tstart > timeout:
                 raise errors.FutureTimeoutError(f'Future timeout on {self._asset}')
 
             time.sleep(3)
             self._asset = self._getter(key)
 
-        if raises and self._asset.status == TupleStatus.failed.name:
+        if raises and self._asset.status == TupleStatus.failed:
             raise errors.FutureFailureError(f'Future execution failed on {self._asset}')
         return self.get()
 
@@ -302,7 +302,7 @@ class OutModel(_DataclassLoader):
 class Traintuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: TupleStatus
+    status: str
     dataset: TupleDataset
     permissions: Permissions
     compute_plan_id: str
@@ -322,7 +322,7 @@ class Traintuple(_Asset, _FutureMixin):
 class Aggregatetuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: TupleStatus
+    status: str
     worker: str
     permissions: Permissions
     compute_plan_id: str
@@ -348,7 +348,7 @@ class OutCompositeModel(_DataclassLoader):
 class CompositeTraintuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: TupleStatus
+    status: str
     dataset: TupleDataset
     compute_plan_id: str
     rank: int
@@ -369,7 +369,7 @@ class CompositeTraintuple(_Asset, _FutureMixin):
 class Testtuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: TupleStatus
+    status: str
     dataset: TupleDataset
     certified: bool
     tag: str

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -1,5 +1,5 @@
 import abc
-from enum import Enum, auto
+import enum
 import dataclasses
 import re
 import time
@@ -21,9 +21,12 @@ class BaseFuture(abc.ABC):
         raise NotImplementedError
 
 
-class TupleStatus(Enum):
-    done = auto()
-    failed = auto()
+class TupleStatus(enum.Enum):
+    doing = enum.auto()
+    done = enum.auto()
+    failed = enum.auto()
+    todo = enum.auto()
+    waiting = enum.auto()
 
 
 class Future(BaseFuture):
@@ -439,19 +442,19 @@ class Node(_Asset):
     is_current: bool
 
 
-class AssetType(Enum):
-    algo = auto()
-    aggregate_algo = auto()
-    aggregatetuple = auto()
-    composite_algo = auto()
-    composite_traintuple = auto()
-    data_sample = auto()
-    dataset = auto()
-    objective = auto()
-    node = auto()
-    testtuple = auto()
-    traintuple = auto()
-    compute_plan = auto()
+class AssetType(enum.Enum):
+    algo = enum.auto()
+    aggregate_algo = enum.auto()
+    aggregatetuple = enum.auto()
+    composite_algo = enum.auto()
+    composite_traintuple = enum.auto()
+    data_sample = enum.auto()
+    dataset = enum.auto()
+    objective = enum.auto()
+    node = enum.auto()
+    testtuple = enum.auto()
+    traintuple = enum.auto()
+    compute_plan = enum.auto()
 
     @classmethod
     def all(cls):

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -1,5 +1,5 @@
 import abc
-import enum
+from enum import Enum, auto
 import dataclasses
 import re
 import time
@@ -19,6 +19,11 @@ class BaseFuture(abc.ABC):
     @abc.abstractmethod
     def get(self):
         raise NotImplementedError
+
+
+class TupleStatus(Enum):
+    done = auto()
+    failed = auto()
 
 
 class Future(BaseFuture):
@@ -43,15 +48,14 @@ class Future(BaseFuture):
         """Wait until completed (done or failed)."""
         tstart = time.time()
         key = self._asset.key
-        completed_statuses = ['done', 'failed']
-        while self._asset.status not in completed_statuses:
+        while self._asset.status not in [TupleStatus.done.name, TupleStatus.failed.name]:
             if time.time() - tstart > timeout:
                 raise errors.FutureTimeoutError(f'Future timeout on {self._asset}')
 
             time.sleep(3)
             self._asset = self._getter(key)
 
-        if raises and self._asset.status == 'failed':
+        if raises and self._asset.status == TupleStatus.failed.name:
             raise errors.FutureFailureError(f'Future execution failed on {self._asset}')
         return self.get()
 
@@ -295,7 +299,7 @@ class OutModel(_DataclassLoader):
 class Traintuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: str
+    status: TupleStatus
     dataset: TupleDataset
     permissions: Permissions
     compute_plan_id: str
@@ -315,7 +319,7 @@ class Traintuple(_Asset, _FutureMixin):
 class Aggregatetuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: str
+    status: TupleStatus
     worker: str
     permissions: Permissions
     compute_plan_id: str
@@ -341,7 +345,7 @@ class OutCompositeModel(_DataclassLoader):
 class CompositeTraintuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: str
+    status: TupleStatus
     dataset: TupleDataset
     compute_plan_id: str
     rank: int
@@ -362,7 +366,7 @@ class CompositeTraintuple(_Asset, _FutureMixin):
 class Testtuple(_Asset, _FutureMixin):
     key: str
     creator: str
-    status: str
+    status: TupleStatus
     dataset: TupleDataset
     certified: bool
     tag: str
@@ -435,19 +439,19 @@ class Node(_Asset):
     is_current: bool
 
 
-class AssetType(enum.Enum):
-    algo = enum.auto()
-    aggregate_algo = enum.auto()
-    aggregatetuple = enum.auto()
-    composite_algo = enum.auto()
-    composite_traintuple = enum.auto()
-    data_sample = enum.auto()
-    dataset = enum.auto()
-    objective = enum.auto()
-    node = enum.auto()
-    testtuple = enum.auto()
-    traintuple = enum.auto()
-    compute_plan = enum.auto()
+class AssetType(Enum):
+    algo = auto()
+    aggregate_algo = auto()
+    aggregatetuple = auto()
+    composite_algo = auto()
+    composite_traintuple = auto()
+    data_sample = auto()
+    dataset = auto()
+    objective = auto()
+    node = auto()
+    testtuple = auto()
+    traintuple = auto()
+    compute_plan = auto()
 
     @classmethod
     def all(cls):

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -4,8 +4,7 @@ import substra
 
 import substratest as sbt
 
-status_done = sbt.client.assets.TupleStatus.done.name
-status_failed = sbt.client.assets.TupleStatus.failed.name
+from substratest import assets
 
 
 def test_tuples_execution_on_same_node(global_execution_env):
@@ -27,14 +26,14 @@ def test_tuples_execution_on_same_node(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     traintuple = session.add_traintuple(spec).future().wait()
-    assert traintuple.status == status_done
+    assert traintuple.status == assets.TupleStatus.done.name
     assert traintuple.out_model is not None
 
     # create testtuple
     # don't create it before to avoid MVCC errors
     spec = factory.create_testtuple(traintuple=traintuple)
     testtuple = session.add_testtuple(spec).future().wait()
-    assert testtuple.status == status_done
+    assert testtuple.status == assets.TupleStatus.done.name
 
     # add a traintuple depending on first traintuple
     spec = factory.create_traintuple(
@@ -45,7 +44,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
         traintuples=[traintuple],
     )
     traintuple = session.add_traintuple(spec).future().wait()
-    assert traintuple.status == status_done
+    assert traintuple.status == assets.TupleStatus.done.name
     assert len(traintuple.in_models) == 1
 
 
@@ -71,7 +70,7 @@ def test_federated_learning_workflow(global_execution_env):
         rank=0,
     )
     traintuple_1 = session.add_traintuple(spec).future().wait()
-    assert traintuple_1.status == status_done
+    assert traintuple_1.status == assets.TupleStatus.done.name
     assert traintuple_1.out_model is not None
     assert traintuple_1.tag == 'foo'
     assert traintuple_1.compute_plan_id is not None
@@ -91,7 +90,7 @@ def test_federated_learning_workflow(global_execution_env):
         rank=1,
     )
     traintuple_2 = session.add_traintuple(spec).future().wait()
-    assert traintuple_2.status == status_done
+    assert traintuple_2.status == assets.TupleStatus.done.name
     assert traintuple_2.out_model is not None
     assert traintuple_2.tag == 'foo'
     assert traintuple_2.compute_plan_id == traintuple_1.compute_plan_id
@@ -121,14 +120,14 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
         data_samples=dataset_2.train_data_sample_keys,
     )
     traintuple = session_1.add_traintuple(spec).future().wait()
-    assert traintuple.status == status_done
+    assert traintuple.status == assets.TupleStatus.done.name
     assert traintuple.out_model is not None
     assert traintuple.dataset.worker == session_2.node_id
 
     # add testtuple; should execute on node 1 (objective dataset is located on node 1)
     spec = factory.create_testtuple(traintuple=traintuple)
     testtuple = session_1.add_testtuple(spec).future().wait()
-    assert testtuple.status == status_done
+    assert testtuple.status == assets.TupleStatus.done.name
     assert testtuple.dataset.worker == session_1.node_id
 
 
@@ -150,7 +149,7 @@ def test_traintuple_execution_failure(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     traintuple = session.add_traintuple(spec).future().wait(raises=False)
-    assert traintuple.status == status_failed
+    assert traintuple.status == assets.TupleStatus.failed.name
     assert traintuple.out_model is None
 
 
@@ -174,7 +173,7 @@ def test_composite_traintuples_execution(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     composite_traintuple_1 = session.add_composite_traintuple(spec).future().wait()
-    assert composite_traintuple_1.status == status_done
+    assert composite_traintuple_1.status == assets.TupleStatus.done.name
     assert composite_traintuple_1.out_head_model is not None
     assert composite_traintuple_1.out_head_model.out_model is not None
     assert composite_traintuple_1.out_trunk_model is not None
@@ -190,14 +189,14 @@ def test_composite_traintuples_execution(global_execution_env):
         trunk_traintuple=composite_traintuple_1,
     )
     composite_traintuple_2 = session.add_composite_traintuple(spec).future().wait()
-    assert composite_traintuple_2.status == status_done
+    assert composite_traintuple_2.status == assets.TupleStatus.done.name
     assert composite_traintuple_2.out_head_model is not None
     assert composite_traintuple_2.out_trunk_model is not None
 
     # add a 'composite' testtuple
     spec = factory.create_testtuple(traintuple=composite_traintuple_2)
     testtuple = session.add_testtuple(spec).future().wait()
-    assert testtuple.status == status_done
+    assert testtuple.status == assets.TupleStatus.done.name
 
     # list composite traintuple
     composite_traintuples = session.list_composite_traintuple()
@@ -244,7 +243,7 @@ def test_aggregatetuple(global_execution_env):
         traintuples=traintuples,
     )
     aggregatetuple = session.add_aggregatetuple(spec).future().wait()
-    assert aggregatetuple.status == status_done
+    assert aggregatetuple.status == assets.TupleStatus.done.name
     assert len(aggregatetuple.in_models) == number_of_traintuples_to_aggregate
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -26,14 +26,14 @@ def test_tuples_execution_on_same_node(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     traintuple = session.add_traintuple(spec).future().wait()
-    assert traintuple.status == assets.TupleStatus.done.name
+    assert traintuple.status == assets.TupleStatus.done
     assert traintuple.out_model is not None
 
     # create testtuple
     # don't create it before to avoid MVCC errors
     spec = factory.create_testtuple(traintuple=traintuple)
     testtuple = session.add_testtuple(spec).future().wait()
-    assert testtuple.status == assets.TupleStatus.done.name
+    assert testtuple.status == assets.TupleStatus.done
 
     # add a traintuple depending on first traintuple
     spec = factory.create_traintuple(
@@ -44,7 +44,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
         traintuples=[traintuple],
     )
     traintuple = session.add_traintuple(spec).future().wait()
-    assert traintuple.status == assets.TupleStatus.done.name
+    assert traintuple.status == assets.TupleStatus.done
     assert len(traintuple.in_models) == 1
 
 
@@ -70,7 +70,7 @@ def test_federated_learning_workflow(global_execution_env):
         rank=0,
     )
     traintuple_1 = session.add_traintuple(spec).future().wait()
-    assert traintuple_1.status == assets.TupleStatus.done.name
+    assert traintuple_1.status == assets.TupleStatus.done
     assert traintuple_1.out_model is not None
     assert traintuple_1.tag == 'foo'
     assert traintuple_1.compute_plan_id is not None
@@ -90,7 +90,7 @@ def test_federated_learning_workflow(global_execution_env):
         rank=1,
     )
     traintuple_2 = session.add_traintuple(spec).future().wait()
-    assert traintuple_2.status == assets.TupleStatus.done.name
+    assert traintuple_2.status == assets.TupleStatus.done
     assert traintuple_2.out_model is not None
     assert traintuple_2.tag == 'foo'
     assert traintuple_2.compute_plan_id == traintuple_1.compute_plan_id
@@ -120,14 +120,14 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
         data_samples=dataset_2.train_data_sample_keys,
     )
     traintuple = session_1.add_traintuple(spec).future().wait()
-    assert traintuple.status == assets.TupleStatus.done.name
+    assert traintuple.status == assets.TupleStatus.done
     assert traintuple.out_model is not None
     assert traintuple.dataset.worker == session_2.node_id
 
     # add testtuple; should execute on node 1 (objective dataset is located on node 1)
     spec = factory.create_testtuple(traintuple=traintuple)
     testtuple = session_1.add_testtuple(spec).future().wait()
-    assert testtuple.status == assets.TupleStatus.done.name
+    assert testtuple.status == assets.TupleStatus.done
     assert testtuple.dataset.worker == session_1.node_id
 
 
@@ -149,7 +149,7 @@ def test_traintuple_execution_failure(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     traintuple = session.add_traintuple(spec).future().wait(raises=False)
-    assert traintuple.status == assets.TupleStatus.failed.name
+    assert traintuple.status == assets.TupleStatus.failed
     assert traintuple.out_model is None
 
 
@@ -173,7 +173,7 @@ def test_composite_traintuples_execution(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     composite_traintuple_1 = session.add_composite_traintuple(spec).future().wait()
-    assert composite_traintuple_1.status == assets.TupleStatus.done.name
+    assert composite_traintuple_1.status == assets.TupleStatus.done
     assert composite_traintuple_1.out_head_model is not None
     assert composite_traintuple_1.out_head_model.out_model is not None
     assert composite_traintuple_1.out_trunk_model is not None
@@ -189,14 +189,14 @@ def test_composite_traintuples_execution(global_execution_env):
         trunk_traintuple=composite_traintuple_1,
     )
     composite_traintuple_2 = session.add_composite_traintuple(spec).future().wait()
-    assert composite_traintuple_2.status == assets.TupleStatus.done.name
+    assert composite_traintuple_2.status == assets.TupleStatus.done
     assert composite_traintuple_2.out_head_model is not None
     assert composite_traintuple_2.out_trunk_model is not None
 
     # add a 'composite' testtuple
     spec = factory.create_testtuple(traintuple=composite_traintuple_2)
     testtuple = session.add_testtuple(spec).future().wait()
-    assert testtuple.status == assets.TupleStatus.done.name
+    assert testtuple.status == assets.TupleStatus.done
 
     # list composite traintuple
     composite_traintuples = session.list_composite_traintuple()
@@ -243,7 +243,7 @@ def test_aggregatetuple(global_execution_env):
         traintuples=traintuples,
     )
     aggregatetuple = session.add_aggregatetuple(spec).future().wait()
-    assert aggregatetuple.status == assets.TupleStatus.done.name
+    assert aggregatetuple.status == assets.TupleStatus.done
     assert len(aggregatetuple.in_models) == number_of_traintuples_to_aggregate
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -4,6 +4,9 @@ import substra
 
 import substratest as sbt
 
+status_done = 'done'
+status_failed = 'failed'
+
 
 def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
@@ -24,14 +27,14 @@ def test_tuples_execution_on_same_node(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     traintuple = session.add_traintuple(spec).future().wait()
-    assert traintuple.status == 'done'
+    assert traintuple.status == status_done
     assert traintuple.out_model is not None
 
     # create testtuple
     # don't create it before to avoid MVCC errors
     spec = factory.create_testtuple(traintuple=traintuple)
     testtuple = session.add_testtuple(spec).future().wait()
-    assert testtuple.status == 'done'
+    assert testtuple.status == status_done
 
     # add a traintuple depending on first traintuple
     spec = factory.create_traintuple(
@@ -42,7 +45,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
         traintuples=[traintuple],
     )
     traintuple = session.add_traintuple(spec).future().wait()
-    assert traintuple.status == 'done'
+    assert traintuple.status == status_done
     assert len(traintuple.in_models) == 1
 
 
@@ -68,7 +71,7 @@ def test_federated_learning_workflow(global_execution_env):
         rank=0,
     )
     traintuple_1 = session.add_traintuple(spec).future().wait()
-    assert traintuple_1.status == 'done'
+    assert traintuple_1.status == status_done
     assert traintuple_1.out_model is not None
     assert traintuple_1.tag == 'foo'
     assert traintuple_1.compute_plan_id is not None
@@ -88,7 +91,7 @@ def test_federated_learning_workflow(global_execution_env):
         rank=1,
     )
     traintuple_2 = session.add_traintuple(spec).future().wait()
-    assert traintuple_2.status == 'done'
+    assert traintuple_2.status == status_done
     assert traintuple_2.out_model is not None
     assert traintuple_2.tag == 'foo'
     assert traintuple_2.compute_plan_id == traintuple_1.compute_plan_id
@@ -118,14 +121,14 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
         data_samples=dataset_2.train_data_sample_keys,
     )
     traintuple = session_1.add_traintuple(spec).future().wait()
-    assert traintuple.status == 'done'
+    assert traintuple.status == status_done
     assert traintuple.out_model is not None
     assert traintuple.dataset.worker == session_2.node_id
 
     # add testtuple; should execute on node 1 (objective dataset is located on node 1)
     spec = factory.create_testtuple(traintuple=traintuple)
     testtuple = session_1.add_testtuple(spec).future().wait()
-    assert testtuple.status == 'done'
+    assert testtuple.status == status_done
     assert testtuple.dataset.worker == session_1.node_id
 
 
@@ -147,7 +150,7 @@ def test_traintuple_execution_failure(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     traintuple = session.add_traintuple(spec).future().wait(raises=False)
-    assert traintuple.status == 'failed'
+    assert traintuple.status == status_failed
     assert traintuple.out_model is None
 
 
@@ -171,7 +174,7 @@ def test_composite_traintuples_execution(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
     )
     composite_traintuple_1 = session.add_composite_traintuple(spec).future().wait()
-    assert composite_traintuple_1.status == 'done'
+    assert composite_traintuple_1.status == status_done
     assert composite_traintuple_1.out_head_model is not None
     assert composite_traintuple_1.out_head_model.out_model is not None
     assert composite_traintuple_1.out_trunk_model is not None
@@ -187,14 +190,14 @@ def test_composite_traintuples_execution(global_execution_env):
         trunk_traintuple=composite_traintuple_1,
     )
     composite_traintuple_2 = session.add_composite_traintuple(spec).future().wait()
-    assert composite_traintuple_2.status == 'done'
+    assert composite_traintuple_2.status == status_done
     assert composite_traintuple_2.out_head_model is not None
     assert composite_traintuple_2.out_trunk_model is not None
 
     # add a 'composite' testtuple
     spec = factory.create_testtuple(traintuple=composite_traintuple_2)
     testtuple = session.add_testtuple(spec).future().wait()
-    assert testtuple.status == 'done'
+    assert testtuple.status == status_done
 
     # list composite traintuple
     composite_traintuples = session.list_composite_traintuple()
@@ -241,7 +244,7 @@ def test_aggregatetuple(global_execution_env):
         traintuples=traintuples,
     )
     aggregatetuple = session.add_aggregatetuple(spec).future().wait()
-    assert aggregatetuple.status == 'done'
+    assert aggregatetuple.status == status_done
     assert len(aggregatetuple.in_models) == number_of_traintuples_to_aggregate
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -4,8 +4,8 @@ import substra
 
 import substratest as sbt
 
-status_done = 'done'
-status_failed = 'failed'
+status_done = sbt.client.assets.TupleStatus.done.name
+status_failed = sbt.client.assets.TupleStatus.failed.name
 
 
 def test_tuples_execution_on_same_node(global_execution_env):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -55,7 +55,7 @@ def test_compute_plan(global_execution_env):
     # check all traintuples are done and check they have been executed on the expected
     # node
     for t in traintuples:
-        assert t.status == assets.TupleStatus.done.name
+        assert t.status == assets.TupleStatus.done
 
     traintuple_1, traintuple_2, traintuple_3 = traintuples
 
@@ -115,7 +115,7 @@ def test_compute_plan_single_session_success(global_execution_env):
 
     # All the train/test tuples should succeed
     for t in cp.list_traintuple() + cp.list_testtuple():
-        assert t.status == assets.TupleStatus.done.name
+        assert t.status == assets.TupleStatus.done
 
 
 def test_compute_plan_single_session_failure(global_execution_env):
@@ -173,7 +173,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
 
     # All the train/test tuples should be marked as failed
     for t in traintuples + testtuples:
-        assert t.status == assets.TupleStatus.failed.name
+        assert t.status == assets.TupleStatus.failed
 
 
 def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
@@ -243,7 +243,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
               cp.list_aggregatetuple() +
               cp.list_testtuple())
     for t in tuples:
-        assert t.status == assets.TupleStatus.done.name
+        assert t.status == assets.TupleStatus.done
 
 
 def test_compute_plan_circular_dependency_failure(global_execution_env):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -2,8 +2,8 @@ import pytest
 import substra
 import substratest as sbt
 
-status_done = 'done'
-status_failed = 'failed'
+status_done = sbt.client.assets.TupleStatus.done.name
+status_failed = sbt.client.assets.TupleStatus.failed.name
 
 
 def test_compute_plan(global_execution_env):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -2,6 +2,9 @@ import pytest
 import substra
 import substratest as sbt
 
+status_done = 'done'
+status_failed = 'failed'
+
 
 def test_compute_plan(global_execution_env):
     """Execution of a compute plan containing multiple traintuples:
@@ -53,7 +56,7 @@ def test_compute_plan(global_execution_env):
     # check all traintuples are done and check they have been executed on the expected
     # node
     for t in traintuples:
-        assert t.status == 'done'
+        assert t.status == status_done
 
     traintuple_1, traintuple_2, traintuple_3 = traintuples
 
@@ -113,7 +116,7 @@ def test_compute_plan_single_session_success(global_execution_env):
 
     # All the train/test tuples should succeed
     for t in cp.list_traintuple() + cp.list_testtuple():
-        assert t.status == 'done'
+        assert t.status == status_done
 
 
 def test_compute_plan_single_session_failure(global_execution_env):
@@ -171,7 +174,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
 
     # All the train/test tuples should be marked as failed
     for t in traintuples + testtuples:
-        assert t.status == 'failed'
+        assert t.status == status_failed
 
 
 def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
@@ -241,7 +244,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
               cp.list_aggregatetuple() +
               cp.list_testtuple())
     for t in tuples:
-        assert t.status == 'done'
+        assert t.status == status_done
 
 
 def test_compute_plan_circular_dependency_failure(global_execution_env):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -2,8 +2,7 @@ import pytest
 import substra
 import substratest as sbt
 
-status_done = sbt.client.assets.TupleStatus.done.name
-status_failed = sbt.client.assets.TupleStatus.failed.name
+from substratest import assets
 
 
 def test_compute_plan(global_execution_env):
@@ -56,7 +55,7 @@ def test_compute_plan(global_execution_env):
     # check all traintuples are done and check they have been executed on the expected
     # node
     for t in traintuples:
-        assert t.status == status_done
+        assert t.status == assets.TupleStatus.done.name
 
     traintuple_1, traintuple_2, traintuple_3 = traintuples
 
@@ -116,7 +115,7 @@ def test_compute_plan_single_session_success(global_execution_env):
 
     # All the train/test tuples should succeed
     for t in cp.list_traintuple() + cp.list_testtuple():
-        assert t.status == status_done
+        assert t.status == assets.TupleStatus.done.name
 
 
 def test_compute_plan_single_session_failure(global_execution_env):
@@ -174,7 +173,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
 
     # All the train/test tuples should be marked as failed
     for t in traintuples + testtuples:
-        assert t.status == status_failed
+        assert t.status == assets.TupleStatus.failed.name
 
 
 def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
@@ -244,7 +243,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
               cp.list_aggregatetuple() +
               cp.list_testtuple())
     for t in tuples:
-        assert t.status == status_done
+        assert t.status == assets.TupleStatus.done.name
 
 
 def test_compute_plan_circular_dependency_failure(global_execution_env):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -7,6 +7,7 @@ from substratest.factory import Permissions
 from . import settings
 
 MSP_IDS = settings.MSP_IDS
+status_done = 'done'
 
 
 @pytest.mark.parametrize('is_public', [True, False])
@@ -127,7 +128,7 @@ def test_merge_permissions(permissions_1, permissions_2, expected_permissions,
         data_samples=[train_data_sample_1],
     )
     traintuple = session_1.add_traintuple(spec).future().wait()
-    assert traintuple.status == 'done'
+    assert traintuple.status == status_done
     assert traintuple.out_model is not None
     assert traintuple.dataset.worker == session_1.node_id
     tuple_permissions = traintuple.permissions.process

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -128,7 +128,7 @@ def test_merge_permissions(permissions_1, permissions_2, expected_permissions,
         data_samples=[train_data_sample_1],
     )
     traintuple = session_1.add_traintuple(spec).future().wait()
-    assert traintuple.status == assets.TupleStatus.done.name
+    assert traintuple.status == assets.TupleStatus.done
     assert traintuple.out_model is not None
     assert traintuple.dataset.worker == session_1.node_id
     tuple_permissions = traintuple.permissions.process

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,14 +1,13 @@
 import substra
-import substratest as sbt
 
 import pytest
 
 from substratest.factory import Permissions
+from substratest import assets
 
 from . import settings
 
 MSP_IDS = settings.MSP_IDS
-status_done = sbt.client.assets.TupleStatus.done.name
 
 
 @pytest.mark.parametrize('is_public', [True, False])
@@ -129,7 +128,7 @@ def test_merge_permissions(permissions_1, permissions_2, expected_permissions,
         data_samples=[train_data_sample_1],
     )
     traintuple = session_1.add_traintuple(spec).future().wait()
-    assert traintuple.status == status_done
+    assert traintuple.status == assets.TupleStatus.done.name
     assert traintuple.out_model is not None
     assert traintuple.dataset.worker == session_1.node_id
     tuple_permissions = traintuple.permissions.process

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,4 +1,5 @@
 import substra
+import substratest as sbt
 
 import pytest
 
@@ -7,7 +8,7 @@ from substratest.factory import Permissions
 from . import settings
 
 MSP_IDS = settings.MSP_IDS
-status_done = 'done'
+status_done = sbt.client.assets.TupleStatus.done.name
 
 
 @pytest.mark.parametrize('is_public', [True, False])


### PR DESCRIPTION
As specified in the related issue, it is better to use global variables or custom type for this status. It improves code readability, code maintainability and is less error prone.

🔗 Related issue: #29 