### PR TITLE
enable skip test due to mvcc conflict

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -399,6 +399,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_traintuple(filters=filters)
         assert len(tuples) == len(self.traintuple_keys)
+        tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 
     def list_composite_traintuple(self):
@@ -407,6 +408,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_composite_traintuple(filters=filters)
         assert len(tuples) == len(self.composite_traintuple_keys)
+        tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 
     def list_aggregatetuple(self):
@@ -415,6 +417,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_aggregatetuple(filters=filters)
         assert len(tuples) == len(self.aggregatetuple_keys)
+        tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 
     def list_testtuple(self):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -3,7 +3,6 @@ import substra
 import substratest as sbt
 
 
-@pytest.mark.skip('may raise MVCC errors')
 def test_compute_plan(global_execution_env):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1


### PR DESCRIPTION
Re enabled the compute plan test. It was skipped due to random MVCC read conflict that are fixed in the backend (https://github.com/SubstraFoundation/substra-backend/pull/71)