### PR TITLE
Fix compute plan test

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -424,6 +424,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_traintuple(filters=filters)
         assert len(tuples) == len(self.traintuple_keys)
+        assert set(self.traintuple_keys) == set([t.key for t in tuples])
         tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 
@@ -433,6 +434,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_composite_traintuple(filters=filters)
         assert len(tuples) == len(self.composite_traintuple_keys)
+        assert set(self.composite_traintuple_keys) == set([t.key for t in tuples])
         tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 
@@ -442,6 +444,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_aggregatetuple(filters=filters)
         assert len(tuples) == len(self.aggregatetuple_keys)
+        assert set(self.aggregatetuple_keys) == set([t.key for t in tuples])
         tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 
@@ -451,6 +454,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         ]
         tuples = self._session.list_testtuple(filters=filters)
         assert len(tuples) == len(self.testtuple_keys)
+        assert set(self.testtuple_keys) == set([t.key for t in tuples])
         tuples = sorted(tuples, key=lambda t: t.rank)
         return tuples
 

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -60,8 +60,15 @@ def test_compute_plan(global_execution_env):
 
     assert len(traintuple_3.in_models) == 2
 
-    assert traintuple_1.dataset.worker == session_1.node_id
-    assert traintuple_2.dataset.worker == session_2.node_id
+    # check tuples rank
+    assert traintuple_1.rank == 0
+    assert traintuple_2.rank == 0
+    assert traintuple_3.rank == 1
+
+    # XXX as the first two tuples have the same rank, there is currently no way to know
+    #     which one will be returned first
+    workers_rank_0 = set([traintuple_1.dataset.worker, traintuple_2.dataset.worker])
+    assert workers_rank_0 == set([session_1.node_id, session_2.node_id])
     assert traintuple_3.dataset.worker == session_1.node_id
 
 


### PR DESCRIPTION
Fix #42 

Random failure due to random ordering of tuples with the same rank.

Thanks @jmorel for the investigation!