### PR TITLE
Remove parsing of skaffold file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ You will need to install it thanks to the `pip` binary.
 
 # Run the tests
 
-The network configuration must be defined in a yaml file.
+The network configuration is described in a yaml file.
 
-Two configurations are currently available:
+Two configuration files are currently available:
 - `values.yaml` (default): for networks started with Kubernetes
 - `local-values.yaml`: for networks started with docker-compose, or started manually
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ You will need to install it thanks to the `pip` binary.
 
 # Run the tests
 
-## Using a network configuration file
+The network configuration must be defined in a yaml file.
 
-This is the mode used by default. Two files are currently available:
+Two configurations are currently available:
 - `values.yaml` (default): for networks started with Kubernetes
 - `local-values.yaml`: for networks started with docker-compose, or started manually
 
@@ -36,13 +36,6 @@ To run the tests using the provided `local-values.yaml` (or a custom config file
 
 ```
 SUBSTRA_TESTS_CONFIG_FILEPATH=local-values.yaml make test
-```
-
-## Using a skaffold file
-
-It is possible to use a `substra-backend` skaffold file as the source for the network configuration:
-```
-SUBSTRA_TESTS_SKAFFOLD_FILEPATH=$SUBSTRA_SOURCE/substra-backend/skaffold.yaml make test
 ```
 
 # Test design guidelines

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,8 +4,6 @@ import os
 import typing
 import yaml
 
-SUBSTRA_TESTS_SKAFFOLD_FILEPATH = os.getenv('SUBSTRA_TESTS_SKAFFOLD_FILEPATH')
-
 CURRENT_DIR = os.path.dirname(__file__)
 
 DEFAULT_NETWORK_CONFIGURATION_PATH = os.path.join(CURRENT_DIR, '../', 'values.yaml')
@@ -53,30 +51,6 @@ def _load_yaml(path):
     )
 
 
-def _load_skaffold(path):
-    """Load configuration from a skaffold yaml file."""
-    with open(path) as f:
-        skaffold = yaml.load(f, Loader=yaml.Loader)
-
-    services = skaffold['deploy']['helm']['releases']
-    backends = [s for s in services if s['name'].startswith('substra-backend-peer')]
-
-    nodes = [NodeCfg(
-        name=b['name'],
-        msp_id=b['overrides']['peer']['mspID'],
-        address=b['overrides']['backend']['defaultDomain'],
-        user=b['overrides']['backend']['auth']['user'],
-        password=b['overrides']['backend']['auth']['password'],
-        shared_path=b['overrides']['persistence']['hostPath'],
-    ) for b in backends]
-
-    return Settings(
-        path=path,
-        nodes=nodes,
-        # the "options" field is not supported when parsing skaffold file
-    )
-
-
 def load():
     """Loads settings static configuration.
 
@@ -88,10 +62,7 @@ def load():
     if _SETTINGS is not None:
         return _SETTINGS
 
-    if SUBSTRA_TESTS_SKAFFOLD_FILEPATH:
-        s = _load_skaffold(SUBSTRA_TESTS_SKAFFOLD_FILEPATH)
-    else:
-        s = _load_yaml(SUBSTRA_TESTS_CONFIG_FILEPATH)
+    s = _load_yaml(SUBSTRA_TESTS_CONFIG_FILEPATH)
     _SETTINGS = s
     return _SETTINGS
 


### PR DESCRIPTION
This mode is unused and it doesn't make sense to maintain it.
It's gonna be harder to support it when the network configuration will be more complex.