### PR TITLE
fix random failures on cancel test

### DIFF
--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -342,7 +342,7 @@ def test_execution_compute_plan_canceled(global_execution_env):
     assert cp.status == assets.Status.canceled
 
     cp = cp.future().wait()
-    assert cp.status in assets.Status.canceled
+    assert cp.status == assets.Status.canceled
 
     # check that the status of the done tuple as not been updated
     first_traintuple = [t for t in cp.list_traintuple() if t.rank == 0][0]


### PR DESCRIPTION
This may not be the best solution to test the different behaviour when cancelling a compute plan.

But this will stop the random failures as a quick term solution.