### PR TITLE
Fix tests that were broken with non local envs

### DIFF
--- a/local-values.yaml
+++ b/local-values.yaml
@@ -1,5 +1,5 @@
 options:
-  celery_task_max_retry: 2
+  celery_task_max_retries: 1
   enable_intermediate_model_removal: False
 nodes:
   - name: 'owkin'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,7 +24,7 @@ class NodeCfg:
 
 @dataclasses.dataclass(frozen=True)
 class Options:
-    celery_task_max_retry: int
+    celery_task_max_retries: int
     enable_intermediate_model_removal: bool
 
 
@@ -43,7 +43,7 @@ def _load_yaml(path):
     with open(path) as f:
         data = yaml.load(f, Loader=yaml.Loader)
     nodes = [NodeCfg(**kw) for kw in data['nodes']]
-    assert len(nodes) >= MIN_NODES, f'not enought nodes: {len(nodes)}'
+    assert len(nodes) >= MIN_NODES, f'not enough nodes: {len(nodes)}'
     return Settings(
         path=path,
         nodes=nodes,
@@ -77,3 +77,5 @@ load()
 
 
 MSP_IDS = [n.msp_id for n in _SETTINGS.nodes]
+HAS_SHARED_PATH = bool(_SETTINGS.nodes[0].shared_path)
+CELERY_TASK_MAX_RETRIES = _SETTINGS.options.celery_task_max_retries

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -5,6 +5,7 @@ import substra
 import pytest
 
 import substratest as sbt
+from . import settings
 
 
 def test_connection_to_nodes(network):
@@ -43,6 +44,7 @@ def test_add_data_sample(factory, session):
     session.add_data_sample(spec)
 
 
+@pytest.mark.skipif(not settings.HAS_SHARED_PATH, reason='requires a shared path')
 def test_add_data_sample_located_in_shared_path(factory, session, node_cfg):
     spec = factory.create_dataset()
     dataset = session.add_dataset(spec)

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 options:
-  celery_task_max_retry: 2
+  celery_task_max_retries: 1
   enable_intermediate_model_removal: False
 nodes:
   - name: 'node-1'


### PR DESCRIPTION
In this PR:
- fix `test_merge_permissions_denied_process ` that is executed only on envs with at least 3 nodes and that hadn't been updated to reflect API changes
- update `celery_task_max_retry` option in `values.yaml`: rename it as `celery_task_max_retries` and make its value the same as the `CELERY_TASK_MAX_RETRIES` option in the backend
- disable shared path test on remote env with no shared path
- make `test_execution_retry_on_fail` work no matter what the `celery_task_max_retries` value is.