### PR TITLE
Add data-type validation with Pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest==5.2.1
 dataclasses==0.7;python_version<"3.7"
+pydantic==1.3

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -167,8 +167,8 @@ class _DataclassLoader(abc.ABC):
 
             if hasattr(attr_type, '__origin__') and attr_type.__origin__ is typing.Union \
                     and len(attr_type.__args__) == 2 and type(None) in attr_type.__args__:
-                attr_type = [arg for arg in attr_type.__args__ if arg
-                             is not type(None)][0]  # noqa: E721
+                attr_type = [arg for arg in attr_type.__args__
+                             if arg is not type(None)][0]  # noqa: E721
 
             # because typing.List doesn't work the same way as the other types, we have to check
             # if attr_type is a class before using issubclass()

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -167,7 +167,8 @@ class _DataclassLoader(abc.ABC):
 
             if hasattr(attr_type, '__origin__') and attr_type.__origin__ is typing.Union \
                     and len(attr_type.__args__) == 2 and type(None) in attr_type.__args__:
-                attr_type = [arg for arg in attr_type.__args__ if arg is not type(None)][0]
+                attr_type = [arg for arg in attr_type.__args__ if arg
+                             is not type(None)][0]  # noqa: E721
 
             # because typing.List doesn't work the same way as the other types, we have to check
             # if attr_type is a class before using issubclass()

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -407,10 +407,10 @@ class Testtuple(_Asset, _FutureMixin):
 class ComputePlan(_Asset, _ComputePlanFutureMixin):
     compute_plan_id: str
     status: str
-    traintuple_keys: typing.List[str] = None
-    composite_traintuple_keys: typing.List[str] = None
-    aggregatetuple_keys: typing.List[str] = None
-    testtuple_keys: typing.List[str] = None
+    traintuple_keys: typing.List[str]
+    composite_traintuple_keys: typing.List[str]
+    aggregatetuple_keys: typing.List[str]
+    testtuple_keys: typing.List[str]
     tag: str
 
     def __init__(self, *args, **kwargs):

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -3,9 +3,9 @@ import enum
 import re
 import time
 import typing
-import pydantic
-
 from inspect import isclass
+
+import pydantic
 
 from . import errors, cfg
 
@@ -163,10 +163,10 @@ class _BaseFutureAsset(_Asset):
 
     @property
     def _session(self):
-        __session = object.__getattribute__(self, '__session')
-        if not __session:
+        session = object.__getattribute__(self, '__session')
+        if not session:
             raise errors.TError(f'No session attached with {self}')
-        return __session
+        return session
 
     def future(self):
         """Returns future from asset."""
@@ -193,16 +193,14 @@ class _Frozen:
 
 
 class _FrozenAsset(_Asset, _Frozen):
-    """Add a Config class to an _Asset, which allows to set allow_mutation to False
-
-    Link to documentation: https://pydantic-docs.helpmanual.io/usage/models/#faux-immutability
+    """Add a Config class to an _Asset, which allows to set allow_mutation to False in order to
+    raise an error if trying to modify the object.
     """
 
 
 class _FrozenInternalStruct(_InternalStruct, _Frozen):
-    """Add a Config class to an _InternalStruct, which allows to set allow_mutation to False
-
-    Link to documentation: https://pydantic-docs.helpmanual.io/usage/models/#faux-immutability
+    """Add a Config class to an _Asset, which allows to set allow_mutation to False in order to
+    raise an error if trying to modify the object.
     """
 
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -163,14 +163,14 @@ class _BaseFutureAsset(_Asset):
 
     @property
     def _session(self):
-        session = object.__getattribute__(self, '__session')
-        if not session:
+        try:
+            return object.__getattribute__(self, '__session')
+        except AttributeError:
             raise errors.TError(f'No session attached with {self}')
-        return session
 
     def future(self):
         """Returns future from asset."""
-        return self._future_cls(self, object.__getattribute__(self, '__session'))
+        return self._future_cls(self, self._session)
 
 
 class _FutureAsset(_BaseFutureAsset):
@@ -193,15 +193,11 @@ class _Frozen:
 
 
 class _FrozenAsset(_Asset, _Frozen):
-    """Add a Config class to an _Asset, which allows to set allow_mutation to False in order to
-    raise an error if trying to modify the object.
-    """
+    """Immutable asset."""
 
 
 class _FrozenInternalStruct(_InternalStruct, _Frozen):
-    """Add a Config class to an _Asset, which allows to set allow_mutation to False in order to
-    raise an error if trying to modify the object.
-    """
+    """Immutable struct."""
 
 
 class Permission(_FrozenInternalStruct):
@@ -280,7 +276,7 @@ class Objective(_FrozenAsset):
     name: str
     owner: str
     permissions: Permissions
-    test_dataset: ObjectiveDataset
+    test_dataset: ObjectiveDataset = None
 
 
 class TesttupleDataset(_FrozenInternalStruct):

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -121,25 +121,29 @@ class _DataclassLoader(abc.ABC):
         mapper = cls.Meta.mapper
         kwargs = {}
         for k, v in d.items():
-            if v is not None:
-                attr_name = mapper[k] if k in mapper else _convert(k)
-                if attr_name not in cls.__annotations__:
-                    continue
-                # handle nested structures;
-                attr_type = cls.__annotations__[attr_name]
-                # because typing.List doesn't work the same way as the other types, we have to check
-                # if attr_type is a class before using issubclass()
-                if isclass(attr_type) and issubclass(attr_type, _DataclassLoader) \
-                        and isinstance(v, dict):
-                    v = attr_type.load(v)
+            if v is None:
+                continue
 
-                elif hasattr(attr_type, '__origin__') and attr_type.__origin__ is list:
-                    attr_args = attr_type.__args__
-                    attr_first_arg = attr_args[0]
-                    if issubclass(attr_first_arg, _DataclassLoader):
-                        v = [attr_first_arg.load(e) for e in v]
+            attr_name = mapper[k] if k in mapper else _convert(k)
+            if attr_name not in cls.__annotations__:
+                continue
+            # handle nested structures;
+            attr_type = cls.__annotations__[attr_name]
+            # because typing.List doesn't work the same way as the other types, we have to check
+            # if attr_type is a class before using issubclass()
+            if isclass(attr_type) and issubclass(attr_type, _DataclassLoader) \
+                    and isinstance(v, dict):
+                v = attr_type.load(v)
 
-                kwargs[attr_name] = v
+            # handle list of internal structures;
+            elif hasattr(attr_type, '__origin__') and attr_type.__origin__ is list \
+                    and isinstance(v, list):
+                list_value_type = attr_type.__args__
+                first_value_type = list_value_type[0]
+                if issubclass(first_value_type, _DataclassLoader):
+                    v = [first_value_type.load(e) for e in v]
+
+            kwargs[attr_name] = v
 
         try:
             return cls(**kwargs)

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -155,7 +155,14 @@ class _InternalStruct(pydantic.BaseModel, _DataclassLoader, abc.ABC):
     """Internal nested structure"""
 
 
-class _BaseFutureAsset(_InternalStruct):
+class _Asset(_InternalStruct, abc.ABC):
+    """Represents assets stored in the Substra framework.
+
+    Convert a dict with camel case fields to a Dataclass.
+    """
+
+
+class _BaseFutureMixin(abc.ABC):
     _future_cls = None
 
     def attach(self, session):
@@ -177,7 +184,7 @@ class _BaseFutureAsset(_InternalStruct):
         return self._future_cls(self, self._session)
 
 
-class _FutureAsset(_BaseFutureAsset):
+class _FutureMixin(_BaseFutureMixin):
     """Represents a single task that is executed on the platform."""
     _future_cls = Future
 
@@ -187,7 +194,7 @@ class _FutureAsset(_BaseFutureAsset):
         return super().future()
 
 
-class _ComputePlanFutureAsset(_BaseFutureAsset):
+class _ComputePlanFutureMixin(_BaseFutureMixin):
     _future_cls = ComputePlanFuture
 
 
@@ -211,7 +218,7 @@ class Permissions(_InternalStruct, _Frozen):
     process: Permission
 
 
-class DataSampleCreated(_InternalStruct, _Frozen):
+class DataSampleCreated(_Asset, _Frozen):
     key: str
     validated: bool
     path: str
@@ -222,7 +229,7 @@ class DataSampleCreated(_InternalStruct, _Frozen):
         }
 
 
-class DataSample(_InternalStruct, _Frozen):
+class DataSample(_Asset, _Frozen):
     key: str
     owner: str
     data_manager_keys: typing.List[str]
@@ -238,7 +245,7 @@ class ObjectiveDataset(_InternalStruct, _Frozen):
         }
 
 
-class Dataset(_InternalStruct, _Frozen):
+class Dataset(_Asset, _Frozen):
     key: str
     name: str
     owner: str
@@ -248,7 +255,7 @@ class Dataset(_InternalStruct, _Frozen):
     test_data_sample_keys: typing.List[str] = None
 
 
-class _Algo(_InternalStruct, _Frozen):
+class _Algo(_Asset, _Frozen):
     key: str
     name: str
     owner: str
@@ -267,7 +274,7 @@ class CompositeAlgo(_Algo):
     pass
 
 
-class Objective(_InternalStruct, _Frozen):
+class Objective(_Asset, _Frozen):
     key: str
     name: str
     owner: str
@@ -318,7 +325,7 @@ class OutModel(_InternalStruct, _Frozen):
         }
 
 
-class Traintuple(_FutureAsset):
+class Traintuple(_Asset, _FutureMixin):
     key: str
     creator: str
     status: str
@@ -337,7 +344,7 @@ class Traintuple(_FutureAsset):
         }
 
 
-class Aggregatetuple(_FutureAsset):
+class Aggregatetuple(_Asset, _FutureMixin):
     key: str
     creator: str
     status: str
@@ -356,12 +363,12 @@ class Aggregatetuple(_FutureAsset):
         }
 
 
-class OutCompositeModel(_InternalStruct, _Frozen):
+class OutCompositeModel(_Asset, _Frozen):
     permissions: Permissions
     out_model: OutModel = None
 
 
-class CompositeTraintuple(_FutureAsset):
+class CompositeTraintuple(_Asset, _FutureMixin):
     key: str
     creator: str
     status: str
@@ -381,7 +388,7 @@ class CompositeTraintuple(_FutureAsset):
         }
 
 
-class Testtuple(_FutureAsset):
+class Testtuple(_Asset, _FutureMixin):
     key: str
     creator: str
     status: str
@@ -397,7 +404,7 @@ class Testtuple(_FutureAsset):
         }
 
 
-class ComputePlan(_ComputePlanFutureAsset):
+class ComputePlan(_Asset, _ComputePlanFutureMixin):
     compute_plan_id: str
     status: str
     traintuple_keys: typing.List[str] = None
@@ -454,7 +461,7 @@ class ComputePlan(_ComputePlanFutureAsset):
         return tuples
 
 
-class Node(_InternalStruct, _Frozen):
+class Node(_Asset, _Frozen):
     id: str
     is_current: bool
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -422,11 +422,11 @@ class ComputePlan(_ComputePlanFutureAsset):
     tag: str
 
     def __init__(self, *args, **kwargs):
+        kwargs['traintuple_keys'] = kwargs.get('traintuple_keys') or []
+        kwargs['composite_traintuple_keys'] = kwargs.get('composite_traintuple_keys') or []
+        kwargs['aggregatetuple_keys'] = kwargs.get('aggregatetuple_keys') or []
+        kwargs['testtuple_keys'] = kwargs.get('testtuple_keys') or []
         super().__init__(*args, **kwargs)
-        self.traintuple_keys = self.traintuple_keys or []
-        self.composite_traintuple_keys = self.composite_traintuple_keys or []
-        self.aggregatetuple_keys = self.aggregatetuple_keys or []
-        self.testtuple_keys = self.testtuple_keys or []
 
     def list_traintuple(self):
         filters = [

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -167,10 +167,7 @@ class _DataclassLoader(abc.ABC):
 
             if hasattr(attr_type, '__origin__') and attr_type.__origin__ is typing.Union \
                     and len(attr_type.__args__) == 2 and type(None) in attr_type.__args__:
-                # noqa: E721
                 attr_type = [arg for arg in attr_type.__args__ if arg is not type(None)][0]
-                # attr_type =
-                # [arg for arg in attr_type.__args__ if not isinstance(arg, type(None))][0]
 
             # because typing.List doesn't work the same way as the other types, we have to check
             # if attr_type is a class before using issubclass()
@@ -205,12 +202,7 @@ class _Asset(_InternalStruct, abc.ABC):
     """
 
 
-class _Frozen:
-    class Config:
-        allow_mutation = False
-
-
-class Permission(_InternalStruct, _Frozen):
+class Permission(_InternalStruct):
     public: bool
     authorized_ids: typing.List[str]
 
@@ -220,12 +212,12 @@ class Permission(_InternalStruct, _Frozen):
         }
 
 
-class Permissions(_InternalStruct, _Frozen):
+class Permissions(_InternalStruct):
     """Permissions structure stored in various asset types."""
     process: Permission
 
 
-class DataSampleCreated(_Asset, _Frozen):
+class DataSampleCreated(_Asset):
     key: str
     validated: bool
     path: str
@@ -236,13 +228,13 @@ class DataSampleCreated(_Asset, _Frozen):
         }
 
 
-class DataSample(_Asset, _Frozen):
+class DataSample(_Asset):
     key: str
     owner: str
     data_manager_keys: typing.List[str]
 
 
-class ObjectiveDataset(_InternalStruct, _Frozen):
+class ObjectiveDataset(_InternalStruct):
     dataset_key: str
     data_sample_keys: typing.List[str]
 
@@ -252,7 +244,7 @@ class ObjectiveDataset(_InternalStruct, _Frozen):
         }
 
 
-class Dataset(_Asset, _Frozen):
+class Dataset(_Asset):
     key: str
     name: str
     owner: str
@@ -264,7 +256,7 @@ class Dataset(_Asset, _Frozen):
     test_data_sample_keys: typing.List[str] = None
 
 
-class _Algo(_Asset, _Frozen):
+class _Algo(_Asset):
     key: str
     name: str
     owner: str
@@ -283,7 +275,7 @@ class CompositeAlgo(_Algo):
     pass
 
 
-class Objective(_Asset, _Frozen):
+class Objective(_Asset):
     key: str
     name: str
     owner: str
@@ -291,7 +283,7 @@ class Objective(_Asset, _Frozen):
     test_dataset: typing.Optional[ObjectiveDataset]
 
 
-class TesttupleDataset(_InternalStruct, _Frozen):
+class TesttupleDataset(_InternalStruct):
     key: str
     perf: float
     keys: typing.List[str]
@@ -303,7 +295,7 @@ class TesttupleDataset(_InternalStruct, _Frozen):
         }
 
 
-class TraintupleDataset(_InternalStruct, _Frozen):
+class TraintupleDataset(_InternalStruct):
     key: str
     keys: typing.List[str]
     worker: str
@@ -314,7 +306,7 @@ class TraintupleDataset(_InternalStruct, _Frozen):
         }
 
 
-class InModel(_InternalStruct, _Frozen):
+class InModel(_InternalStruct):
     key: str
     storage_address: str
 
@@ -324,7 +316,7 @@ class InModel(_InternalStruct, _Frozen):
         }
 
 
-class OutModel(_InternalStruct, _Frozen):
+class OutModel(_InternalStruct):
     key: str
     storage_address: str
 
@@ -372,7 +364,7 @@ class Aggregatetuple(_Asset, _FutureMixin):
         }
 
 
-class OutCompositeModel(_Asset, _Frozen):
+class OutCompositeModel(_Asset):
     permissions: Permissions
     out_model: typing.Optional[OutModel]
 
@@ -470,7 +462,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
         return tuples
 
 
-class Node(_Asset, _Frozen):
+class Node(_Asset):
     id: str
     is_current: bool
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -155,14 +155,7 @@ class _InternalStruct(pydantic.BaseModel, _DataclassLoader, abc.ABC):
     """Internal nested structure"""
 
 
-class _Asset(_InternalStruct, abc.ABC):
-    """Represents assets stored in the Substra framework.
-
-    Convert a dict with camel case fields to a Dataclass.
-    """
-
-
-class _BaseFutureAsset(_Asset):
+class _BaseFutureAsset(_InternalStruct):
     _future_cls = None
 
     def attach(self, session):
@@ -203,15 +196,7 @@ class _Frozen:
         allow_mutation = False
 
 
-class _FrozenAsset(_Asset, _Frozen):
-    """Immutable asset."""
-
-
-class _FrozenInternalStruct(_InternalStruct, _Frozen):
-    """Immutable struct."""
-
-
-class Permission(_FrozenInternalStruct):
+class Permission(_InternalStruct, _Frozen):
     public: bool
     authorized_ids: typing.List[str]
 
@@ -221,12 +206,12 @@ class Permission(_FrozenInternalStruct):
         }
 
 
-class Permissions(_FrozenInternalStruct):
+class Permissions(_InternalStruct, _Frozen):
     """Permissions structure stored in various asset types."""
     process: Permission
 
 
-class DataSampleCreated(_FrozenAsset):
+class DataSampleCreated(_InternalStruct, _Frozen):
     key: str
     validated: bool
     path: str
@@ -237,13 +222,13 @@ class DataSampleCreated(_FrozenAsset):
         }
 
 
-class DataSample(_FrozenAsset):
+class DataSample(_InternalStruct, _Frozen):
     key: str
     owner: str
     data_manager_keys: typing.List[str]
 
 
-class ObjectiveDataset(_FrozenInternalStruct):
+class ObjectiveDataset(_InternalStruct, _Frozen):
     dataset_key: str
     data_sample_keys: typing.List[str]
 
@@ -253,7 +238,7 @@ class ObjectiveDataset(_FrozenInternalStruct):
         }
 
 
-class Dataset(_FrozenAsset):
+class Dataset(_InternalStruct, _Frozen):
     key: str
     name: str
     owner: str
@@ -263,7 +248,7 @@ class Dataset(_FrozenAsset):
     test_data_sample_keys: typing.List[str] = None
 
 
-class _Algo(_FrozenAsset):
+class _Algo(_InternalStruct, _Frozen):
     key: str
     name: str
     owner: str
@@ -282,7 +267,7 @@ class CompositeAlgo(_Algo):
     pass
 
 
-class Objective(_FrozenAsset):
+class Objective(_InternalStruct, _Frozen):
     key: str
     name: str
     owner: str
@@ -290,7 +275,7 @@ class Objective(_FrozenAsset):
     test_dataset: ObjectiveDataset = None
 
 
-class TesttupleDataset(_FrozenInternalStruct):
+class TesttupleDataset(_InternalStruct, _Frozen):
     key: str
     perf: float
     keys: typing.List[str]
@@ -302,7 +287,7 @@ class TesttupleDataset(_FrozenInternalStruct):
         }
 
 
-class TraintupleDataset(_FrozenInternalStruct):
+class TraintupleDataset(_InternalStruct, _Frozen):
     key: str
     keys: typing.List[str]
     worker: str
@@ -313,7 +298,7 @@ class TraintupleDataset(_FrozenInternalStruct):
         }
 
 
-class InModel(_FrozenInternalStruct):
+class InModel(_InternalStruct, _Frozen):
     key: str
     storage_address: str
 
@@ -323,7 +308,7 @@ class InModel(_FrozenInternalStruct):
         }
 
 
-class OutModel(_FrozenInternalStruct):
+class OutModel(_InternalStruct, _Frozen):
     key: str
     storage_address: str
 
@@ -371,7 +356,7 @@ class Aggregatetuple(_FutureAsset):
         }
 
 
-class OutCompositeModel(_FrozenInternalStruct):
+class OutCompositeModel(_InternalStruct, _Frozen):
     permissions: Permissions
     out_model: OutModel = None
 
@@ -469,7 +454,7 @@ class ComputePlan(_ComputePlanFutureAsset):
         return tuples
 
 
-class Node(_FrozenAsset):
+class Node(_InternalStruct, _Frozen):
     id: str
     is_current: bool
 


### PR DESCRIPTION
🔗 Related issue: #37 

This PR aims to add a **data-type validation** on substra-tests in order to be able to check the type of data returned by the [backend](http://github.com/SubstraFoundation/substra-backend) and to return an error is the type received is not the one expected.
We needed to find a library for this.

Some ideas of libraries have been explored:
• [Marshmallow](https://github.com/marshmallow-code/marshmallow)
• [Pydantic](https://github.com/samuelcolvin/pydantic) 
• [MYPY](https://github.com/python/mypy)

We tried to use Marshmallow first, but its wasn't compatible with how substra-tests is made. Indeed, the class instantiation wasn't what we expected and didn't work.
MYPY can be used, but not as a data-type validation tool as we wanted.

So we decided to use **Pydantic** instead of these two options.