### PR TITLE
Add a fast mode for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,8 @@ pyclean:
 test: pyclean
 	pytest tests -rs -v --durations=0
 
+fast-test: pyclean
+	pytest tests -rs -v --durations=0 -m "not slow"
+
 install:
 	pip3 install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ pyclean:
 test: pyclean
 	pytest tests -rs -v --durations=0
 
-fast-test: pyclean
+test-minimal: pyclean
 	pytest tests -rs -v --durations=0 -m "not slow"
 
 install:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip3 install -r requirements.txt
 The tests suite requires a Substra network up and running. The network can be started
 either with skaffold (Kubernetes), with docker-compose, or manually.
 
-The substra project is needed for running the tests.  
+The substra project is needed for running the tests.
 It can be found [here](https://github.com/SubstraFoundation/substra)
 
 You will need to install it thanks to the `pip` binary.
@@ -37,6 +37,18 @@ To run the tests using the provided `local-values.yaml` (or a custom config file
 ```
 SUBSTRA_TESTS_CONFIG_FILEPATH=local-values.yaml make test
 ```
+
+# Fast mode
+
+Since tests can take a long time to run, some of them as marked as slow. You can run the "fast" ones with:
+
+```
+make fast-test
+```
+
+Note that `test_compute_plan` from `test_execution_compute_plan.py` is not marked as slow even though it takes several
+seconds to complete. This is because it covers a very basic use case of the platform and is needed to ensure basic
+features aren't broken.
 
 # Test design guidelines
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SUBSTRA_TESTS_CONFIG_FILEPATH=local-values.yaml make test
 
 # Fast mode
 
-Since tests can take a long time to run, some of them as marked as slow. You can run the "fast" ones with:
+Since tests can take a long time to run, some of them are marked as slow. You can run the "fast" ones with:
 
 ```
 make fast-test

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ SUBSTRA_TESTS_CONFIG_FILEPATH=local-values.yaml make test
 Since tests can take a long time to run, some of them are marked as slow. You can run the "fast" ones with:
 
 ```
-make fast-test
+make test-minimal
 ```
 
 Note that `test_compute_plan` from `test_execution_compute_plan.py` is not marked as slow even though it takes several

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run the tests using the provided `local-values.yaml` (or a custom config file
 SUBSTRA_TESTS_CONFIG_FILEPATH=local-values.yaml make test
 ```
 
-# Fast mode
+# Minimal mode
 
 Since tests can take a long time to run, some of them are marked as slow. You can run the "fast" ones with:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,12 @@ def pytest_report_header(config):
     return messages
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+
+
 @dataclasses.dataclass
 class Network:
     options: settings.Options

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -8,6 +8,7 @@ from substratest import assets
 from . import settings
 
 
+@pytest.mark.slow
 def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
     factory, network = global_execution_env
@@ -51,6 +52,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
     assert len(traintuple.in_models) == 1
 
 
+@pytest.mark.slow
 def test_federated_learning_workflow(global_execution_env):
     """Test federated learning workflow on each node."""
     factory, network = global_execution_env
@@ -94,6 +96,7 @@ def test_federated_learning_workflow(global_execution_env):
     assert cp.status == assets.Status.done
 
 
+@pytest.mark.slow
 def test_tuples_execution_on_different_nodes(global_execution_env):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
@@ -125,6 +128,7 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
     assert testtuple.dataset.worker == session_1.node_id
 
 
+@pytest.mark.slow
 def test_traintuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
     factory, network = global_execution_env
@@ -145,6 +149,7 @@ def test_traintuple_execution_failure(global_execution_env):
     assert traintuple.out_model is None
 
 
+@pytest.mark.slow
 def test_composite_traintuples_execution(global_execution_env):
     """Execution of composite traintuples."""
 
@@ -196,6 +201,7 @@ def test_composite_traintuples_execution(global_execution_env):
     )
 
 
+@pytest.mark.slow
 def test_aggregatetuple(global_execution_env):
     """Execution of aggregatetuple aggregating traintuples."""
 
@@ -234,6 +240,7 @@ def test_aggregatetuple(global_execution_env):
     assert len(aggregatetuple.in_models) == number_of_traintuples_to_aggregate
 
 
+@pytest.mark.slow
 def test_aggregate_composite_traintuples(global_execution_env):
     """Do 2 rounds of composite traintuples aggregations on multiple nodes.
 

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -5,6 +5,7 @@ import substratest as sbt
 from substratest import assets
 
 
+@pytest.mark.slow
 def test_compute_plan(global_execution_env):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
@@ -73,6 +74,7 @@ def test_compute_plan(global_execution_env):
     assert traintuple_3.dataset.worker == session_1.node_id
 
 
+@pytest.mark.slow
 def test_compute_plan_single_session_success(global_execution_env):
     """A compute plan with 3 traintuples and 3 associated testtuples"""
 
@@ -134,6 +136,7 @@ def test_compute_plan_single_session_success(global_execution_env):
         assert t.status == assets.Status.done
 
 
+@pytest.mark.slow
 def test_compute_plan_single_session_failure(global_execution_env):
     """In a compute plan with 3 traintuples, failing the root traintuple
     should cancel its descendents and the associated testtuples"""
@@ -201,6 +204,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
         assert t.status in [assets.Status.failed, assets.Status.canceled]
 
 
+@pytest.mark.slow
 def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
     """
     Compute plan version of the `test_aggregate_composite_traintuples` method from `test_execution.py`
@@ -304,6 +308,7 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
     assert 'missing dependency among inModels IDs' in str(e.value)
 
 
+@pytest.mark.slow
 def test_execution_compute_plan_canceled(global_execution_env):
     factory, network = global_execution_env
     session = network.sessions[0].copy()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -5,7 +5,6 @@ import substratest as sbt
 from substratest import assets
 
 
-@pytest.mark.slow
 def test_compute_plan(global_execution_env):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -162,6 +162,7 @@ def test_permissions_denied_process(factory, network):
         session_1.add_traintuple(spec)
 
 
+@pytest.mark.slow
 @pytest.mark.xfail(reason='permission check not yet implemented in the backend')
 def test_permissions_denied_model_process(factory, network):
     session_1 = network.sessions[0]


### PR DESCRIPTION
Fixes #41 

Creates a new "slow" marker for tests and adds a new `fast-test` target in Makefile that will only run "fast" tests.

With the current tests marked as slow, `make test` runs in 184s for 71 tests while `make fast-test` runs in 48s for 59 tests.