### PR TITLE
Fix: dataset can be linked with only one objective

### DIFF
--- a/substratest/client.py
+++ b/substratest/client.py
@@ -262,3 +262,8 @@ class Session:
         compute_plan = assets.ComputePlan.load(res).attach(self)
         self.state.update_compute_plan(compute_plan)
         return compute_plan
+
+    def link_dataset_with_objective(self, dataset, objective):
+        self._client.link_dataset_with_objective(dataset.key, objective.key)
+        # XXX do not return anything as currently the chaincode simply returns the
+        #     updated dataset key

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -183,6 +183,7 @@ class DatasetSpec(_Spec):
     type: str
     description: str
     permissions: Permissions = None
+    objective_key: str = None
 
     def read_opener(self):
         with open(self.data_opener, 'rb') as f:
@@ -442,7 +443,7 @@ class AssetsFactory:
             data_manager_keys=[d.key for d in datasets],
         )
 
-    def create_dataset(self, permissions=None):
+    def create_dataset(self, objective=None, permissions=None):
         rdm = random.random()
         idx = self._dataset_counter.inc()
         tmpdir = self._workdir / f'dataset-{idx}'
@@ -464,6 +465,7 @@ class AssetsFactory:
             data_opener=str(opener_path),
             type='Test',
             description=str(description_path),
+            objective_key=objective.key if objective else None,
             permissions=permissions or DEFAULT_PERMISSIONS,
         )
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -33,6 +33,26 @@ def test_add_dataset_conflict(factory, session):
     assert dataset == dataset_copy
 
 
+def test_link_dataset_with_objective(factory, session):
+    spec = factory.create_objective()
+    objective_1 = session.add_objective(spec)
+
+    spec = factory.create_objective()
+    objective_2 = session.add_objective(spec)
+
+    spec = factory.create_dataset()
+    dataset = session.add_dataset(spec)
+
+    # link dataset with objective
+    session.link_dataset_with_objective(dataset, objective_1)
+    dataset = session.get_dataset(dataset.key)
+    assert dataset.objective_key == objective_1.key
+
+    # ensure an existing dataset cannot be linked to more than one objective
+    with pytest.raises(substra.exceptions.InvalidRequest):
+        session.link_dataset_with_objective(dataset, objective_2)
+
+
 def test_add_data_sample(factory, session):
     spec = factory.create_dataset()
     dataset = session.add_dataset(spec)
@@ -77,6 +97,15 @@ def test_add_objective(factory, session):
     objective = session.add_objective(spec)
     objective_copy = session.get_objective(objective.key)
     assert objective == objective_copy
+
+    # check dataset has been linked with the objective after objective creation
+    dataset = session.get_dataset(dataset.key)
+    assert dataset.objective_key == objective.key
+
+    # add a new dataset and ensure it is linked with the created objective
+    spec = factory.create_dataset(objective=objective)
+    dataset = session.add_dataset(spec)
+    assert dataset.objective_key == objective.key
 
 
 def test_add_algo(factory, session):


### PR DESCRIPTION
Add more tests to cover link between dataset and objective

Companion PRs:
- [substra](https://github.com/SubstraFoundation/substra/pull/94)
- [backend](https://github.com/SubstraFoundation/substra-backend/pull/133)