### PR TITLE
Improved asset code

### DIFF
--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -15,9 +15,6 @@ DEFAULT_DATA_SAMPLE_FILENAME = 'data.csv'
 
 DEFAULT_SUBSTRATOOLS_VERSION = '0.5.0'
 
-# TODO improve opener get_X/get_y methods
-# TODO improve metrics score method
-
 DEFAULT_OPENER_SCRIPT = f"""
 import csv
 import json
@@ -25,17 +22,17 @@ import os
 import substratools as tools
 class TestOpener(tools.Opener):
     def get_X(self, folders):
-        res = 0
+        res = []
         for folder in folders:
             with open(os.path.join(folder, '{DEFAULT_DATA_SAMPLE_FILENAME}'), 'r') as f:
                 reader = csv.reader(f)
                 for row in reader:
-                    res += int(row[0])
+                    res.append(int(row[0]))
         return res
     def get_y(self, folders):
         return len(folders)
     def fake_X(self):
-        return 1
+        return [2]
     def fake_y(self):
         return 1
     def get_predictions(self, path):
@@ -51,7 +48,7 @@ import json
 import substratools as tools
 class TestMetrics(tools.Metrics):
     def score(self, y_true, y_pred):
-        return y_pred -y_true
+        return y_pred - y_true
 if __name__ == '__main__':
     tools.metrics.execute(TestMetrics())
 """
@@ -61,7 +58,7 @@ import json
 import substratools as tools
 class TestAlgo(tools.Algo):
     def train(self, X, y, models, rank):
-        return sum(models) + X
+        return sum(models) + sum(X)
     def predict(self, X, model):
         return model
     def load_model(self, path):
@@ -97,7 +94,7 @@ import json
 import substratools as tools
 class TestCompositeAlgo(tools.CompositeAlgo):
     def train(self, X, y, head_model, trunk_model, rank):
-        out_head_model = head_model + X if head_model else X
+        out_head_model = head_model + sum(X) if head_model else sum(X)
         out_trunk_model = trunk_model + y if trunk_model else y
         return out_head_model, out_trunk_model
     def predict(self, X, head_model, trunk_model):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -69,7 +69,7 @@ def load():
 
 # TODO that's a bad idea to expose the static configuration, it has been done to allow
 #      tests parametrization but this won't work for specific tests written with more
-#      more nodes
+#      nodes
 
 # load configuration at module load time to allow tests parametrization depending on
 # network static configuration

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -27,18 +27,21 @@ def test_compute_plan(global_execution_env):
     # create compute plan
     cp_spec = factory.create_compute_plan(tag='foo')
 
+    # out model value should be 8
     traintuple_spec_1 = cp_spec.add_traintuple(
         algo=algo_2,
         dataset=dataset_1,
         data_samples=dataset_1.train_data_sample_keys,
     )
 
+    # out model value should be 8
     traintuple_spec_2 = cp_spec.add_traintuple(
         algo=algo_2,
         dataset=dataset_2,
         data_samples=dataset_2.train_data_sample_keys,
     )
 
+    # out model value should be 24 (16 from 2 in models + 8 from data samples)
     traintuple_spec_3 = cp_spec.add_traintuple(
         algo=algo_2,
         dataset=dataset_1,
@@ -46,6 +49,7 @@ def test_compute_plan(global_execution_env):
         in_models=[traintuple_spec_1, traintuple_spec_2],
     )
 
+    # perf should be 23 (24 from model - 1 from y)
     cp_spec.add_testtuple(
         objective=objective_1,
         traintuple_spec=traintuple_spec_3,
@@ -79,6 +83,9 @@ def test_compute_plan(global_execution_env):
     assert traintuple_2.rank == 0
     assert traintuple_3.rank == 1
     assert testtuple.rank == traintuple_3.rank
+
+    # check testtuple perf
+    assert testtuple.dataset.perf == 23
 
     # XXX as the first two tuples have the same rank, there is currently no way to know
     #     which one will be returned first


### PR DESCRIPTION
Attempted fix of #14 

The idea behind the change is to make every sample and model an int:
- a data sample value is 2
- a dataset X value is the sum of the X value of each data samples (i.e. `2*len(folders)` by default)
- a dataset y value is the number of data samples
- an out model value is the sum of the value of all in models + X
- an aggregate value is the average of all in model values
- an out head model value is the sum of the value of all in head models + X
- an out trunk model value is the sum of the value of all in trunk models + y

A prediction is the value of the model (or head model + trunk model for composite algos)

The score is the difference between the prediction and actual y (ie. tuple model value - number of testtpules).