### PR TITLE
Improved asset code (with realistic interfaces)

### DIFF
--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -16,21 +16,32 @@ DEFAULT_DATA_SAMPLE_FILENAME = 'data.csv'
 
 DEFAULT_SUBSTRATOOLS_VERSION = '0.6.0'
 
-# TODO improve opener get_X/get_y methods
-# TODO improve metrics score method
-
-DEFAULT_OPENER_SCRIPT = """
+DEFAULT_OPENER_SCRIPT = f"""
+import csv
 import json
+import os
 import substratools as tools
 class TestOpener(tools.Opener):
     def get_X(self, folders):
-        return folders
+        res = []
+        for folder in folders:
+            with open(os.path.join(folder, '{DEFAULT_DATA_SAMPLE_FILENAME}'), 'r') as f:
+                reader = csv.reader(f)
+                for row in reader:
+                    res.append(int(row[0]))
+        return res  # returns a list of 1's
     def get_y(self, folders):
-        return folders
-    def fake_X(self, n_samples=None):
-        return 'fakeX'
-    def fake_y(self, n_samples=None):
-        return 'fakey'
+        res = []
+        for folder in folders:
+            with open(os.path.join(folder, '{DEFAULT_DATA_SAMPLE_FILENAME}'), 'r') as f:
+                reader = csv.reader(f)
+                for row in reader:
+                    res.append(int(row[1]))
+        return res  # returns a list of 2's
+    def fake_X(self):
+        return [1]
+    def fake_y(self):
+        return [2]
     def get_predictions(self, path):
         with open(path) as f:
             return json.load(f)
@@ -44,7 +55,7 @@ import json
 import substratools as tools
 class TestMetrics(tools.Metrics):
     def score(self, y_true, y_pred):
-        return 101
+        return sum(y_pred) - sum(y_true)
 if __name__ == '__main__':
     tools.metrics.execute(TestMetrics())
 """
@@ -54,15 +65,28 @@ import json
 import substratools as tools
 class TestAlgo(tools.Algo):
     def train(self, X, y, models, rank):
-        return [0, 1]
+
+        ratio = sum(y) / sum(X)
+        err = 0.1 * ratio  # Add a small error
+
+        if len(models) == 0:
+            return {{'value': ratio + err }}
+        else:
+            ratios = [m['value'] for m in models]
+            avg = sum(ratios) / len(ratios)
+            return {{'value': avg + err }}
+
     def predict(self, X, model):
-        return [0, 99]
+        return [x * model['value'] for x in X]
+
     def load_model(self, path):
         with open(path) as f:
             return json.load(f)
+
     def save_model(self, model, path):
         with open(path, 'w') as f:
             return json.dump(model, f)
+
 if __name__ == '__main__':
     tools.algo.execute(TestAlgo())
 """
@@ -72,7 +96,9 @@ import json
 import substratools as tools
 class TestAggregateAlgo(tools.AggregateAlgo):
     def aggregate(self, models, rank):
-        return [0, 66]
+        values = [m['value'] for m in models]
+        avg = sum(values) / len(values)
+        return {{'value': avg}}
     def load_model(self, path):
         with open(path) as f:
             return json.load(f)
@@ -90,23 +116,47 @@ import json
 import substratools as tools
 class TestCompositeAlgo(tools.CompositeAlgo):
     def train(self, X, y, head_model, trunk_model, rank):
-        return [0, 1], [0, 2]
+
+        ratio = sum(y) / sum(X)
+        err_head = 0.1 * ratio  # Add a small error
+        err_trunk = 0.2 * ratio  # Add a small error
+
+        if head_model:
+            res_head = head_model['value']
+        else:
+            res_head = ratio
+
+        if trunk_model:
+            res_trunk = trunk_model['value']
+        else:
+            res_trunk = ratio
+        return {{'value' : res_head + err_head }}, {{'value' : res_trunk + err_trunk }}
+
     def predict(self, X, head_model, trunk_model):
-        return [0, 99]
+        ratio_sum = head_model['value'] + trunk_model['value']
+        res = [x * ratio_sum for x in X]
+        return res
+
     def load_head_model(self, path):
         return self._load_model(path)
+
     def save_head_model(self, model, path):
         return self._save_model(model, path)
+
     def load_trunk_model(self, path):
         return self._load_model(path)
+
     def save_trunk_model(self, model, path):
         return self._save_model(model, path)
+
     def _load_model(self, path):
         with open(path) as f:
             return json.load(f)
+
     def _save_model(self, model, path):
         with open(path, 'w') as f:
             return json.dump(model, f)
+
 if __name__ == '__main__':
     tools.algo.execute(TestCompositeAlgo())
 """
@@ -445,8 +495,11 @@ class AssetsFactory:
         tmpdir.mkdir()
 
         encoding = 'utf-8'
-        content = content or f'0,{idx}'.encode(encoding)
-        content = f'# random={rdm} \n'.encode(encoding) + content
+        if content:
+            content = f'# random={rdm} \n'.encode(encoding) + content
+        else:
+            # x=1, y=2. The last "random" column ensures the datasample is unique.
+            content = f'1,2,{rdm}\n'.encode(encoding)
 
         data_filepath = tmpdir / DEFAULT_DATA_SAMPLE_FILENAME
         with open(data_filepath, 'wb') as f:

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -38,10 +38,10 @@ class TestOpener(tools.Opener):
                 for row in reader:
                     res.append(int(row[1]))
         return res  # returns a list of 2's
-    def fake_X(self):
-        return [1]
-    def fake_y(self):
-        return [2]
+    def fake_X(self, n_samples=1):
+        return [1] * n_samples
+    def fake_y(self, n_samples=1):
+        return [2] * n_samples
     def get_predictions(self, path):
         with open(path) as f:
             return json.load(f)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -69,7 +69,7 @@ def load():
 
 # TODO that's a bad idea to expose the static configuration, it has been done to allow
 #      tests parametrization but this won't work for specific tests written with more
-#      more nodes
+#      nodes
 
 # load configuration at module load time to allow tests parametrization depending on
 # network static configuration

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -36,6 +36,7 @@ def test_tuples_execution_on_same_node(factory, client, default_dataset, default
     spec = factory.create_testtuple(objective=default_objective, traintuple=traintuple)
     testtuple = client.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
+    assert testtuple.dataset.perf == 0.2
 
     # add a traintuple depending on first traintuple
     spec = factory.create_traintuple(
@@ -115,6 +116,7 @@ def test_tuples_execution_on_different_nodes(factory, client_1, client_2, defaul
     testtuple = client_1.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
     assert testtuple.dataset.worker == client_1.node_id
+    assert testtuple.dataset.perf == 0.2
 
 
 @pytest.mark.slow
@@ -221,6 +223,7 @@ def test_composite_traintuples_execution(factory, client, default_dataset, defau
     spec = factory.create_testtuple(objective=default_objective, traintuple=composite_traintuple_2)
     testtuple = client.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
+    assert testtuple.dataset.perf == 3.2
 
     # list composite traintuple
     composite_traintuples = client.list_composite_traintuple()
@@ -346,7 +349,8 @@ def test_aggregate_composite_traintuples(factory, network, clients, default_data
             objective=objective,
             traintuple=traintuple,
         )
-        clients[0].add_testtuple(spec).future().wait()
+        testtuple = clients[0].add_testtuple(spec).future().wait()
+        assert testtuple.dataset.perf == 3.2
 
     if not network.options.enable_intermediate_model_removal:
         return

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -90,6 +90,9 @@ def test_compute_plan(factory, client_1, client_2, default_dataset_1, default_da
     assert traintuple_3.rank == 1
     assert testtuple.rank == traintuple_3.rank
 
+    # check testtuple perf
+    assert testtuple.dataset.perf == 0.4
+
     # XXX as the first two tuples have the same rank, there is currently no way to know
     #     which one will be returned first
     workers_rank_0 = set([traintuple_1.dataset.worker, traintuple_2.dataset.worker])


### PR DESCRIPTION
As discussed with @jmorel here is an alternative implementation for the opener/algo/metrics.

They are meant to 1. have an implementation that is very simple and 2. use interfaces that match the intended usage, in particular:

- `train` returns a model structure
- `predict` calculates `y` based on the input `model` and the input `X` 

Please let me know your thoughts. I'm particularly interested in feedback on the comments,

## Performance impact

I compared the time it takes to run `make test` between:

- `master`
- `improved_asset_code`
- `improved_asset_code_v2`

I ran `make test` 10x on each branch. Both `improved_asset_code` and `improved_asset_code_v2` take longer to run, but the increase is very small.

![image](https://user-images.githubusercontent.com/168382/73698991-a1be1980-46b0-11ea-9e6b-3db0a22ccf82.png)

(those numbers are not worth much, it's just to get a general idea of the size of the increase)

In a future iteration, we could make changes so that the new algo/opener/metrics are only used for a few specific tests that ensure that data flows correctly between opener, algo and metrics. All the other tests could use a dummy algo that does nothing (like in `master`). This would shave a few seconds :man_shrugging: 
