### PR TITLE
Split session object into client and state

### DIFF
--- a/substratest/client.py
+++ b/substratest/client.py
@@ -15,12 +15,6 @@ class Session:
     Parses responses from server to return Asset instances.
     """
 
-    # The Session object still uses the self.state attribute. But it is still required for the
-    # add_asset methods. Question is: how to replace it in these methods?
-    # Ideas:
-    # Move these methods to the State object?
-    # Add directly self.assets in the __init__? Absolutely not what we want.
-
     def __init__(self, node_name, node_id, address, user, password):
         super().__init__()
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -11,7 +11,6 @@ DATASET_DOWNLOAD_FILENAME = 'opener.py'
 class Session:
     """Client to interact with a Node of Substra.
 
-    Stores asset(s) added during the session.
     Parses responses from server to return Asset instances.
     """
 

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -9,7 +9,7 @@ from . import assets
 DATASET_DOWNLOAD_FILENAME = 'opener.py'
 
 
-class _State:
+class State:
     """Session state.
 
     Represents all the assets that have been added during the life of the session.
@@ -68,7 +68,7 @@ class Session:
     def __init__(self, node_name, node_id, address, user, password):
         super().__init__()
         # session added/modified assets during the session lifetime
-        self.state = _State()
+        self.state = State()
 
         # node / client
         self.node_id = node_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 
 import substratest as sbt
+from substratest.client import State
 from . import settings
 
 
@@ -117,6 +118,56 @@ def global_execution_env():
             sess.add_objective(spec)
 
         yield f, n
+
+
+@pytest.fixture(scope='session')
+def global_execution_env_copy():
+    """Network fixture with pre-existing assets in all nodes.
+
+    The following asssets will be created for each node:
+    - 4 train data samples
+    - 1 test data sample
+    - 1 dataset
+    - 1 objective
+
+    Network must started outside of the tests environment and the network is kept
+    alive while running all tests.
+
+    Returns a tuple (factory, state, Network)
+    """
+    n = _get_network()
+    s = State()
+    factory_name = f"{TESTS_RUN_UUID}_global"
+
+    with sbt.AssetsFactory(name=factory_name) as f:
+        for sess in n.sessions:
+
+            # create dataset
+            spec = f.create_dataset()
+            dataset = sess.add_dataset(spec)
+
+            # create train data samples
+            for i in range(4):
+                spec = f.create_data_sample(datasets=[dataset], test_only=False)
+                data_sample = sess.add_data_sample(spec)
+                s.train_data_samples.append(data_sample)
+
+            # create test data sample
+            spec = f.create_data_sample(datasets=[dataset], test_only=True)
+            test_data_sample = sess.add_data_sample(spec)
+            s.test_data_samples.append(test_data_sample)
+
+            # reload datasets (to ensure they are properly linked with the created data samples)
+            dataset = sess.get_dataset(dataset.key)
+            s.datasets.append(dataset)
+
+            # create objective
+            spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
+            objective = sess.add_objective(spec)
+            s.objectives.append(objective)
+
+        print(s.train_data_samples)
+        yield f, s, n
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import uuid
 import pytest
 
 import substratest as sbt
-from substratest.client import State
 from . import settings
 
 
@@ -29,6 +28,28 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     )
+
+
+# TODO replace by dataclass? // object Pydantic?
+class _State:
+    """Session state.
+    # TODO edit description
+    Represents all the assets that have been added during the life of the session.
+    """
+
+    def __init__(self):  # TODO remove unused attributes
+        self.datasets = []
+        self.test_data_samples = []
+        self.train_data_samples = []
+        self.objectives = []
+        # self.algos = []
+        # self.aggregate_algos = []
+        # self.composite_algos = []
+        # self.traintuples = []
+        # self.aggregatetuples = []
+        # self.composite_traintuples = []
+        # self.testtuples = []
+        # self.compute_plans = []
 
 
 @dataclasses.dataclass
@@ -93,7 +114,7 @@ def global_execution_env():
     Returns a tuple (factory, state, Network)
     """
     n = _get_network()
-    s = State()
+    s = _State()
     factory_name = f"{TESTS_RUN_UUID}_global"
 
     with sbt.AssetsFactory(name=factory_name) as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,49 +90,6 @@ def global_execution_env():
     Network must started outside of the tests environment and the network is kept
     alive while running all tests.
 
-    Returns a tuple (factory, Network)
-    """
-    n = _get_network()
-    factory_name = f"{TESTS_RUN_UUID}_global"
-    with sbt.AssetsFactory(name=factory_name) as f:
-        for sess in n.sessions:
-
-            # create dataset
-            spec = f.create_dataset()
-            dataset = sess.add_dataset(spec)
-
-            # create train data samples
-            for i in range(4):
-                spec = f.create_data_sample(datasets=[dataset], test_only=False)
-                sess.add_data_sample(spec)
-
-            # create test data sample
-            spec = f.create_data_sample(datasets=[dataset], test_only=True)
-            test_data_sample = sess.add_data_sample(spec)
-
-            # reload datasets (to ensure they are properly linked with the created data samples)
-            dataset = sess.get_dataset(dataset.key)
-
-            # create objective
-            spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
-            sess.add_objective(spec)
-
-        yield f, n
-
-
-@pytest.fixture(scope='session')
-def global_execution_env_copy():
-    """Network fixture with pre-existing assets in all nodes.
-
-    The following asssets will be created for each node:
-    - 4 train data samples
-    - 1 test data sample
-    - 1 dataset
-    - 1 objective
-
-    Network must started outside of the tests environment and the network is kept
-    alive while running all tests.
-
     Returns a tuple (factory, state, Network)
     """
     n = _get_network()
@@ -166,7 +123,6 @@ def global_execution_env_copy():
             objective = sess.add_objective(spec)
             s.objectives.append(objective)
 
-        print(s.train_data_samples)
         yield f, s, n
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import typing
 import uuid
 
 import pytest
+import pydantic
 
 import substratest as sbt
 from . import settings
@@ -30,26 +31,15 @@ def pytest_configure(config):
     )
 
 
-# TODO replace by dataclass? // object Pydantic?
-class _State:
-    """Session state.
-    # TODO edit description
-    Represents all the assets that have been added during the life of the session.
-    """
+class _State(pydantic.BaseModel):
+    """Current state.
 
-    def __init__(self):  # TODO remove unused attributes
-        self.datasets = []
-        self.test_data_samples = []
-        self.train_data_samples = []
-        self.objectives = []
-        # self.algos = []
-        # self.aggregate_algos = []
-        # self.composite_algos = []
-        # self.traintuples = []
-        # self.aggregatetuples = []
-        # self.composite_traintuples = []
-        # self.testtuples = []
-        # self.compute_plans = []
+    Represents all the assets that have been added during the tests.
+    """
+    datasets: typing.List[sbt.client.assets.Dataset] = []
+    test_data_samples: typing.List[sbt.client.assets.DataSampleCreated] = []
+    train_data_samples: typing.List[sbt.client.assets.DataSampleCreated] = []
+    objectives: typing.List[sbt.client.assets.Objective] = []
 
 
 @dataclasses.dataclass

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -10,9 +10,9 @@ from . import settings
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_same_node(global_execution_env_copy):
+def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -54,9 +54,9 @@ def test_tuples_execution_on_same_node(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_federated_learning_workflow(global_execution_env_copy):
+def test_federated_learning_workflow(global_execution_env):
     """Test federated learning workflow on each node."""
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     # create test environment
@@ -98,10 +98,10 @@ def test_federated_learning_workflow(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_different_nodes(global_execution_env_copy):
+def test_tuples_execution_on_different_nodes(global_execution_env):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session_1 = network.sessions[0].copy()
     session_2 = network.sessions[1].copy()
 
@@ -130,9 +130,9 @@ def test_tuples_execution_on_different_nodes(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_traintuple_execution_failure(global_execution_env_copy):
+def test_traintuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -151,9 +151,9 @@ def test_traintuple_execution_failure(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_composite_traintuple_execution_failure(global_execution_env_copy):
+def test_composite_traintuple_execution_failure(global_execution_env):
     """Invalid composite algo script is causing traintuple failure."""
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -173,9 +173,9 @@ def test_composite_traintuple_execution_failure(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_aggregatetuple_execution_failure(global_execution_env_copy):
+def test_aggregatetuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -209,10 +209,10 @@ def test_aggregatetuple_execution_failure(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_composite_traintuples_execution(global_execution_env_copy):
+def test_composite_traintuples_execution(global_execution_env):
     """Execution of composite traintuples."""
 
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -261,12 +261,12 @@ def test_composite_traintuples_execution(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_aggregatetuple(global_execution_env_copy):
+def test_aggregatetuple(global_execution_env):
     """Execution of aggregatetuple aggregating traintuples."""
 
     number_of_traintuples_to_aggregate = 3
 
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -300,7 +300,7 @@ def test_aggregatetuple(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_aggregate_composite_traintuples(global_execution_env_copy):
+def test_aggregate_composite_traintuples(global_execution_env):
     """Do 2 rounds of composite traintuples aggregations on multiple nodes.
 
     Compute plan details:
@@ -328,7 +328,7 @@ def test_aggregate_composite_traintuples(global_execution_env_copy):
 
     This test refers to the model composition use case.
     """
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     sessions = [s.copy() for s in network.sessions]
 
     aggregate_worker = sessions[0].node_id
@@ -419,7 +419,7 @@ def test_aggregate_composite_traintuples(global_execution_env_copy):
     (settings.CELERY_TASK_MAX_RETRIES, 'done'),
     (settings.CELERY_TASK_MAX_RETRIES + 1, 'failed'),
 ))
-def test_execution_retry_on_fail(fail_count, status, global_execution_env_copy):
+def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     """Execution of a traintuple which fails on the N first tries, and suceeds on the N+1th try"""
 
     # This test ensures the compute task retry mechanism works correctly.
@@ -462,7 +462,7 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env_copy):
     # The counter is greater than the retry count
     tools.algo.execute(TestAlgo())"""
 
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -13,7 +13,7 @@ from . import settings
 def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     objective = [o for o in state.objectives if o.owner == session.node_id][0]
@@ -57,14 +57,16 @@ def test_tuples_execution_on_same_node(global_execution_env):
 def test_federated_learning_workflow(global_execution_env):
     """Test federated learning workflow on each node."""
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     # create test environment
     spec = factory.create_algo()
     algo = session.add_algo(spec)
 
     # get first dataset of each session
-    datasets = [d for d in state.datasets]
+    # because there is only one dataset created by session, we can get all the datasets
+    datasets = state.datasets
+
     # check there is one dataset per node in the network
     assert set([d.owner for d in datasets]) == set([s.node_id for s in network.sessions])
 
@@ -102,8 +104,8 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
     factory, state, network = global_execution_env
-    session_1 = network.sessions[0].copy()
-    session_2 = network.sessions[1].copy()
+    session_1 = network.sessions[0]
+    session_2 = network.sessions[1]
 
     objective_1 = [o for o in state.objectives if o.owner == session_1.node_id][0]
     dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
@@ -133,7 +135,7 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
 def test_traintuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
@@ -154,7 +156,7 @@ def test_traintuple_execution_failure(global_execution_env):
 def test_composite_traintuple_execution_failure(global_execution_env):
     """Invalid composite algo script is causing traintuple failure."""
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
@@ -176,7 +178,7 @@ def test_composite_traintuple_execution_failure(global_execution_env):
 def test_aggregatetuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
@@ -213,7 +215,7 @@ def test_composite_traintuples_execution(global_execution_env):
     """Execution of composite traintuples."""
 
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     objective = [o for o in state.objectives if o.owner == session.node_id][0]
@@ -267,7 +269,7 @@ def test_aggregatetuple(global_execution_env):
     number_of_traintuples_to_aggregate = 3
 
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     train_data_sample_keys = dataset.train_data_sample_keys[:number_of_traintuples_to_aggregate]
@@ -329,15 +331,13 @@ def test_aggregate_composite_traintuples(global_execution_env):
     This test refers to the model composition use case.
     """
     factory, state, network = global_execution_env
-    sessions = [s.copy() for s in network.sessions]
+    sessions = network.sessions
 
     aggregate_worker = sessions[0].node_id
     number_of_rounds = 2
 
-    datasets = [d for d in state.datasets if d.owner == sessions[0].node_id] + \
-               [d for d in state.datasets if d.owner == sessions[1].node_id]
-    objectives = [o for o in state.objectives if o.owner == sessions[0].node_id][:0] + \
-                 [o for o in state.objectives if o.owner == sessions[1].node_id][:0]
+    datasets = state.datasets
+    objectives = state.objectives
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -463,7 +463,7 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     tools.algo.execute(TestAlgo())"""
 
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -12,11 +12,11 @@ from . import settings
 @pytest.mark.slow
 def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
-    objective = [o for o in state.objectives if o.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -56,7 +56,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
 @pytest.mark.slow
 def test_federated_learning_workflow(global_execution_env):
     """Test federated learning workflow on each node."""
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
     # create test environment
@@ -65,7 +65,7 @@ def test_federated_learning_workflow(global_execution_env):
 
     # get first dataset of each session
     # because there is only one dataset created by session, we can get all the datasets
-    datasets = state.datasets
+    datasets = initial_assets.datasets
 
     # check there is one dataset per node in the network
     assert set([d.owner for d in datasets]) == set([s.node_id for s in network.sessions])
@@ -103,12 +103,12 @@ def test_federated_learning_workflow(global_execution_env):
 def test_tuples_execution_on_different_nodes(global_execution_env):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session_1 = network.sessions[0]
     session_2 = network.sessions[1]
 
-    objective_1 = [o for o in state.objectives if o.owner == session_1.node_id][0]
-    dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
+    objective_1 = [o for o in initial_assets.objectives if o.owner == session_1.node_id][0]
+    dataset_2 = [d for d in initial_assets.datasets if d.owner == session_2.node_id][0]
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)
@@ -134,10 +134,10 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
 @pytest.mark.slow
 def test_traintuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = session.add_algo(spec)
@@ -155,10 +155,10 @@ def test_traintuple_execution_failure(global_execution_env):
 @pytest.mark.slow
 def test_composite_traintuple_execution_failure(global_execution_env):
     """Invalid composite algo script is causing traintuple failure."""
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_composite_algo(py_script=sbt.factory.INVALID_COMPOSITE_ALGO_SCRIPT)
     algo = session.add_composite_algo(spec)
@@ -177,10 +177,10 @@ def test_composite_traintuple_execution_failure(global_execution_env):
 @pytest.mark.slow
 def test_aggregatetuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_composite_algo()
     composite_algo = session.add_composite_algo(spec)
@@ -214,11 +214,11 @@ def test_aggregatetuple_execution_failure(global_execution_env):
 def test_composite_traintuples_execution(global_execution_env):
     """Execution of composite traintuples."""
 
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
-    objective = [o for o in state.objectives if o.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_composite_algo()
     algo = session.add_composite_algo(spec)
@@ -268,10 +268,10 @@ def test_aggregatetuple(global_execution_env):
 
     number_of_traintuples_to_aggregate = 3
 
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
     train_data_sample_keys = dataset.train_data_sample_keys[:number_of_traintuples_to_aggregate]
 
     spec = factory.create_algo()
@@ -330,14 +330,14 @@ def test_aggregate_composite_traintuples(global_execution_env):
 
     This test refers to the model composition use case.
     """
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     sessions = network.sessions
 
     aggregate_worker = sessions[0].node_id
     number_of_rounds = 2
 
-    datasets = state.datasets
-    objectives = state.objectives
+    datasets = initial_assets.datasets
+    objectives = initial_assets.objectives
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -403,7 +403,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
     # username/password are not available in the settings files.
 
     session = sessions[0]
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
     algo = session.add_algo(spec)
 
     spec = factory.create_traintuple(
@@ -462,10 +462,10 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     # The counter is greater than the retry count
     tools.algo.execute(TestAlgo())"""
 
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
 
     py_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(retry_algo_snippet_toreplace, retry_snippet_replacement)
     spec = factory.create_algo(py_script)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -10,13 +10,13 @@ from . import settings
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_same_node(global_execution_env):
+def test_tuples_execution_on_same_node(global_execution_env_copy):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
-    objective = session.state.objectives[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    objective = [d for d in state.objectives if d.owner == session.node_id][0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -54,9 +54,9 @@ def test_tuples_execution_on_same_node(global_execution_env):
 
 
 @pytest.mark.slow
-def test_federated_learning_workflow(global_execution_env):
+def test_federated_learning_workflow(global_execution_env_copy):
     """Test federated learning workflow on each node."""
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
     # create test environment
@@ -64,7 +64,7 @@ def test_federated_learning_workflow(global_execution_env):
     algo = session.add_algo(spec)
 
     # get first dataset of each session
-    datasets = [s.state.datasets[0] for s in network.sessions]
+    datasets = [d for d in state.datasets]
     # check there is one dataset per node in the network
     assert set([d.owner for d in datasets]) == set([s.node_id for s in network.sessions])
 
@@ -98,15 +98,15 @@ def test_federated_learning_workflow(global_execution_env):
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_different_nodes(global_execution_env):
+def test_tuples_execution_on_different_nodes(global_execution_env_copy):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session_1 = network.sessions[0].copy()
     session_2 = network.sessions[1].copy()
 
-    objective_1 = session_1.state.objectives[0]
-    dataset_2 = session_2.state.datasets[0]
+    objective_1 = [d for d in state.objectives if d.owner == session_1.node_id][0]
+    dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)
@@ -130,12 +130,12 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
 
 
 @pytest.mark.slow
-def test_traintuple_execution_failure(global_execution_env):
+def test_traintuple_execution_failure(global_execution_env_copy):
     """Invalid algo script is causing traintuple failure."""
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = session.add_algo(spec)
@@ -151,12 +151,12 @@ def test_traintuple_execution_failure(global_execution_env):
 
 
 @pytest.mark.slow
-def test_composite_traintuple_execution_failure(global_execution_env):
+def test_composite_traintuple_execution_failure(global_execution_env_copy):
     """Invalid composite algo script is causing traintuple failure."""
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_composite_algo(py_script=sbt.factory.INVALID_COMPOSITE_ALGO_SCRIPT)
     algo = session.add_composite_algo(spec)
@@ -173,12 +173,12 @@ def test_composite_traintuple_execution_failure(global_execution_env):
 
 
 @pytest.mark.slow
-def test_aggregatetuple_execution_failure(global_execution_env):
+def test_aggregatetuple_execution_failure(global_execution_env_copy):
     """Invalid algo script is causing traintuple failure."""
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_composite_algo()
     composite_algo = session.add_composite_algo(spec)
@@ -209,14 +209,14 @@ def test_aggregatetuple_execution_failure(global_execution_env):
 
 
 @pytest.mark.slow
-def test_composite_traintuples_execution(global_execution_env):
+def test_composite_traintuples_execution(global_execution_env_copy):
     """Execution of composite traintuples."""
 
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
-    objective = session.state.objectives[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    objective = [d for d in state.objectives if d.owner == session.node_id][0]
 
     spec = factory.create_composite_algo()
     algo = session.add_composite_algo(spec)
@@ -261,15 +261,15 @@ def test_composite_traintuples_execution(global_execution_env):
 
 
 @pytest.mark.slow
-def test_aggregatetuple(global_execution_env):
+def test_aggregatetuple(global_execution_env_copy):
     """Execution of aggregatetuple aggregating traintuples."""
 
     number_of_traintuples_to_aggregate = 3
 
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     train_data_sample_keys = dataset.train_data_sample_keys[:number_of_traintuples_to_aggregate]
 
     spec = factory.create_algo()
@@ -300,7 +300,7 @@ def test_aggregatetuple(global_execution_env):
 
 
 @pytest.mark.slow
-def test_aggregate_composite_traintuples(global_execution_env):
+def test_aggregate_composite_traintuples(global_execution_env_copy):
     """Do 2 rounds of composite traintuples aggregations on multiple nodes.
 
     Compute plan details:
@@ -328,14 +328,16 @@ def test_aggregate_composite_traintuples(global_execution_env):
 
     This test refers to the model composition use case.
     """
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     sessions = [s.copy() for s in network.sessions]
 
     aggregate_worker = sessions[0].node_id
     number_of_rounds = 2
 
-    datasets = sessions[0].state.datasets + sessions[1].state.datasets
-    objectives = sessions[0].state.objectives[:0] + sessions[1].state.objectives[:0]
+    datasets = [d for d in state.datasets if d.owner == sessions[0].node_id] + \
+               [d for d in state.datasets if d.owner == sessions[1].node_id]
+    objectives = [d for d in state.objectives if d.owner == sessions[0].node_id][:0] + \
+                 [d for d in state.objectives if d.owner == sessions[1].node_id][:0]
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -401,7 +403,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
     # username/password are not available in the settings files.
 
     session = sessions[0]
-    dataset = session.state.datasets[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     algo = session.add_algo(spec)
 
     spec = factory.create_traintuple(
@@ -417,7 +419,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
     (settings.CELERY_TASK_MAX_RETRIES, 'done'),
     (settings.CELERY_TASK_MAX_RETRIES + 1, 'failed'),
 ))
-def test_execution_retry_on_fail(fail_count, status, global_execution_env):
+def test_execution_retry_on_fail(fail_count, status, global_execution_env_copy):
     """Execution of a traintuple which fails on the N first tries, and suceeds on the N+1th try"""
 
     # This test ensures the compute task retry mechanism works correctly.
@@ -460,10 +462,10 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     # The counter is greater than the retry count
     tools.algo.execute(TestAlgo())"""
 
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session = network.sessions[0].copy()
 
-    dataset = session.state.datasets[0]
+    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
     py_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(retry_algo_snippet_toreplace, retry_snippet_replacement)
     spec = factory.create_algo(py_script)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -16,7 +16,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
-    objective = [d for d in state.objectives if d.owner == session.node_id][0]
+    objective = [o for o in state.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -105,7 +105,7 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
     session_1 = network.sessions[0].copy()
     session_2 = network.sessions[1].copy()
 
-    objective_1 = [d for d in state.objectives if d.owner == session_1.node_id][0]
+    objective_1 = [o for o in state.objectives if o.owner == session_1.node_id][0]
     dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
 
     spec = factory.create_algo()
@@ -216,7 +216,7 @@ def test_composite_traintuples_execution(global_execution_env):
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
-    objective = [d for d in state.objectives if d.owner == session.node_id][0]
+    objective = [o for o in state.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_composite_algo()
     algo = session.add_composite_algo(spec)
@@ -336,8 +336,8 @@ def test_aggregate_composite_traintuples(global_execution_env):
 
     datasets = [d for d in state.datasets if d.owner == sessions[0].node_id] + \
                [d for d in state.datasets if d.owner == sessions[1].node_id]
-    objectives = [d for d in state.objectives if d.owner == sessions[0].node_id][:0] + \
-                 [d for d in state.objectives if d.owner == sessions[1].node_id][:0]
+    objectives = [o for o in state.objectives if o.owner == sessions[0].node_id][:0] + \
+                 [o for o in state.objectives if o.owner == sessions[1].node_id][:0]
 
     # register algos on first node
     spec = factory.create_composite_algo()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -6,14 +6,14 @@ from substratest.factory import Permissions
 from substratest import assets
 
 
-def test_compute_plan(global_execution_env_copy):
+def test_compute_plan(global_execution_env):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
     - 1 traintuple executed on node 2
     - 1 traintuple executed on node 1 depending on previous traintuples
     - 1 testtuple executed on node 1 depending on the last traintuple
     """
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session_1 = network.sessions[0].copy()
     session_2 = network.sessions[1].copy()
 
@@ -100,7 +100,7 @@ def test_compute_plan(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_compute_plan_single_session_success(global_execution_env_copy):
+def test_compute_plan_single_session_success(global_execution_env):
     """A compute plan with 3 traintuples and 3 associated testtuples"""
 
     # Create a compute plan with 3 steps:
@@ -109,7 +109,7 @@ def test_compute_plan_single_session_success(global_execution_env_copy):
     # 2. traintuple + testtuple
     # 3. traintuple + testtuple
 
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -162,13 +162,13 @@ def test_compute_plan_single_session_success(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_compute_plan_update(global_execution_env_copy):
+def test_compute_plan_update(global_execution_env):
     """A compute plan with 3 traintuples and 3 associated testtuples.
 
     This is done by sending 3 requests (one create and two updates).
     """
 
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -231,7 +231,7 @@ def test_compute_plan_update(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_compute_plan_single_session_failure(global_execution_env_copy):
+def test_compute_plan_single_session_failure(global_execution_env):
     """In a compute plan with 3 traintuples, failing the root traintuple
     should cancel its descendents and the associated testtuples"""
 
@@ -243,7 +243,7 @@ def test_compute_plan_single_session_failure(global_execution_env_copy):
     #
     # Intentionally use an invalid (broken) algo.
 
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -299,11 +299,11 @@ def test_compute_plan_single_session_failure(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_compute_plan_aggregate_composite_traintuples(global_execution_env_copy):
+def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
     """
     Compute plan version of the `test_aggregate_composite_traintuples` method from `test_execution.py`
     """
-    factory, state, network = global_execution_env_copy
+    factory, state, network = global_execution_env
     sessions = [s.copy() for s in network.sessions]
 
     aggregate_worker = sessions[0].node_id
@@ -373,8 +373,8 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env_copy)
         assert t.status == assets.Status.done
 
 
-def test_compute_plan_circular_dependency_failure(global_execution_env_copy):
-    factory, state, network = global_execution_env_copy
+def test_compute_plan_circular_dependency_failure(global_execution_env):
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
@@ -406,8 +406,8 @@ def test_compute_plan_circular_dependency_failure(global_execution_env_copy):
 
 
 @pytest.mark.slow
-def test_execution_compute_plan_canceled(global_execution_env_copy):
-    factory, state, network = global_execution_env_copy
+def test_execution_compute_plan_canceled(global_execution_env):
+    factory, state, network = global_execution_env
     session = network.sessions[0].copy()
 
     # XXX A canceled compute plan can be done if the it is canceled while it last tuples

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -312,8 +312,8 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
     # register objectives, datasets, and data samples
     datasets = [d for d in state.datasets if d.owner == sessions[0].node_id] + \
                [d for d in state.datasets if d.owner == sessions[1].node_id]
-    objectives = [d for d in state.objectives if d.owner == sessions[0].node_id][:0] + \
-               [d for d in state.objectives if d.owner == sessions[1].node_id][:0]
+    objectives = [o for o in state.objectives if o.owner == sessions[0].node_id][:0] + \
+                 [o for o in state.objectives if o.owner == sessions[1].node_id][:0]
 
     # register algos on first node
     spec = factory.create_composite_algo()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -13,14 +13,14 @@ def test_compute_plan(global_execution_env):
     - 1 traintuple executed on node 1 depending on previous traintuples
     - 1 testtuple executed on node 1 depending on the last traintuple
     """
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session_1 = network.sessions[0]
     session_2 = network.sessions[1]
 
-    dataset_1 = [d for d in state.datasets if d.owner == session_1.node_id][0]
-    dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
+    dataset_1 = [d for d in initial_assets.datasets if d.owner == session_1.node_id][0]
+    dataset_2 = [d for d in initial_assets.datasets if d.owner == session_2.node_id][0]
 
-    objective_1 = [o for o in state.objectives if o.owner == session_1.node_id][0]
+    objective_1 = [o for o in initial_assets.objectives if o.owner == session_1.node_id][0]
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)
@@ -109,12 +109,12 @@ def test_compute_plan_single_session_success(global_execution_env):
     # 2. traintuple + testtuple
     # 3. traintuple + testtuple
 
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = [o for o in state.objectives if o.owner == session.node_id][0]
+    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -168,12 +168,12 @@ def test_compute_plan_update(global_execution_env):
     This is done by sending 3 requests (one create and two updates).
     """
 
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = [o for o in state.objectives if o.owner == session.node_id][0]
+    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -243,12 +243,12 @@ def test_compute_plan_single_session_failure(global_execution_env):
     #
     # Intentionally use an invalid (broken) algo.
 
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = [o for o in state.objectives if o.owner == session.node_id][0]
+    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = session.add_algo(spec)
@@ -303,15 +303,15 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
     """
     Compute plan version of the `test_aggregate_composite_traintuples` method from `test_execution.py`
     """
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     sessions = network.sessions
 
     aggregate_worker = sessions[0].node_id
     number_of_rounds = 2
 
     # register objectives, datasets, and data samples
-    datasets = state.datasets
-    objectives = state.objectives
+    datasets = initial_assets.datasets
+    objectives = initial_assets.objectives
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -372,10 +372,10 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
 
 
 def test_compute_plan_circular_dependency_failure(global_execution_env):
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -405,7 +405,7 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
 
 @pytest.mark.slow
 def test_execution_compute_plan_canceled(global_execution_env):
-    factory, state, network = global_execution_env
+    factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
     # XXX A canceled compute plan can be done if the it is canceled while it last tuples
@@ -415,7 +415,7 @@ def test_execution_compute_plan_canceled(global_execution_env):
     #     compute plan with a large amount of tuples.
     nb_traintuples = 32
 
-    dataset = [d for d in state.datasets if d.owner == session.node_id][0]
+    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
     data_sample_key = dataset.train_data_sample_keys[0]
 
     spec = factory.create_algo()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -14,8 +14,8 @@ def test_compute_plan(global_execution_env):
     - 1 testtuple executed on node 1 depending on the last traintuple
     """
     factory, state, network = global_execution_env
-    session_1 = network.sessions[0].copy()
-    session_2 = network.sessions[1].copy()
+    session_1 = network.sessions[0]
+    session_2 = network.sessions[1]
 
     dataset_1 = [d for d in state.datasets if d.owner == session_1.node_id][0]
     dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
@@ -110,7 +110,7 @@ def test_compute_plan_single_session_success(global_execution_env):
     # 3. traintuple + testtuple
 
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
@@ -169,7 +169,7 @@ def test_compute_plan_update(global_execution_env):
     """
 
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
@@ -244,7 +244,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
     # Intentionally use an invalid (broken) algo.
 
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
@@ -304,16 +304,14 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
     Compute plan version of the `test_aggregate_composite_traintuples` method from `test_execution.py`
     """
     factory, state, network = global_execution_env
-    sessions = [s.copy() for s in network.sessions]
+    sessions = network.sessions
 
     aggregate_worker = sessions[0].node_id
     number_of_rounds = 2
 
     # register objectives, datasets, and data samples
-    datasets = [d for d in state.datasets if d.owner == sessions[0].node_id] + \
-               [d for d in state.datasets if d.owner == sessions[1].node_id]
-    objectives = [o for o in state.objectives if o.owner == sessions[0].node_id][:0] + \
-                 [o for o in state.objectives if o.owner == sessions[1].node_id][:0]
+    datasets = state.datasets
+    objectives = state.objectives
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -375,7 +373,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
 
 def test_compute_plan_circular_dependency_failure(global_execution_env):
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     dataset = [d for d in state.datasets if d.owner == session.node_id][0]
 
@@ -408,7 +406,7 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
 @pytest.mark.slow
 def test_execution_compute_plan_canceled(global_execution_env):
     factory, state, network = global_execution_env
-    session = network.sessions[0].copy()
+    session = network.sessions[0]
 
     # XXX A canceled compute plan can be done if the it is canceled while it last tuples
     #     are executing on the workers. The compute plan status will in this case change

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -6,21 +6,22 @@ from substratest.factory import Permissions
 from substratest import assets
 
 
-def test_compute_plan(global_execution_env):
+def test_compute_plan(global_execution_env_copy):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
     - 1 traintuple executed on node 2
     - 1 traintuple executed on node 1 depending on previous traintuples
     - 1 testtuple executed on node 1 depending on the last traintuple
     """
-    factory, network = global_execution_env
+    factory, state, network = global_execution_env_copy
     session_1 = network.sessions[0].copy()
     session_2 = network.sessions[1].copy()
 
-    dataset_1 = session_1.state.datasets[0]
-    dataset_2 = session_2.state.datasets[0]
+    dataset_1 = [d for d in state.datasets if d.owner == session_1.node_id][0]
 
-    objective_1 = session_1.state.objectives[0]
+    dataset_2 = [d for d in state.datasets if d.owner == session_2.node_id][0]
+
+    objective_1 = [o for o in state.objectives if o.owner == session_1.node_id][0]
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)


### PR DESCRIPTION
🔗 **Related issue:** #76 

Currently each session has its own state which contains the assets created (and owned) by the session during the current test run.

The objective of the session is to contain all assets necessary for the execution of a test. For example, the fixture global_execution_env returns sessions which contain all necessary assets to run test_aggregatetuple

In order to better reflect this, we'd like to separate the session object into 2 independent object:

- Client (replaces Session) is a wrapper around substra.Client to handle serialization
- State is an independent object with private properties (state._dataset) and public methods to access assets owned by a given node (state.get_dataset(node_id))

Fixtures such as global_execution_env would then not return a factory and a network but instead a factory and a state containing all assets created by the fixture.

Individual tests such as test_aggregatetuple would therefore need to get as args the fixture global_execution_env and a clients fixture (or multiple individual fixtures client_1, client_2 etc.)

This will lead to a pretty big renaming throughout the tests (no more sessions, only clients and states instead)