### PR TITLE
Add Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+DOCKER_TAG := latest
+DOCKER_TAG_SUBSTRA := latest
+
+.PHONY: pyclean test test-minimal install docker
+
 pyclean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
@@ -10,3 +15,6 @@ test-minimal: pyclean
 
 install:
 	pip3 install -r requirements.txt
+
+docker:
+	docker build -f docker/Dockerfile . -t substra-tests:$(DOCKER_TAG) --build-arg SUBSTRA_VERSION=$(DOCKER_TAG_SUBSTRA)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+override CWD := $(shell basename $(shell pwd))
+DOCKER_IMG := $(CWD)
 DOCKER_TAG := latest
-DOCKER_TAG_SUBSTRA := latest
+SUBSTRA_GIT_REPO := https://github.com/SubstraFoundation/substra.git
+SUBSTRA_GIT_REF := master
 
 .PHONY: pyclean test test-minimal install docker
 
@@ -16,5 +19,14 @@ test-minimal: pyclean
 install:
 	pip3 install -r requirements.txt
 
+# Usage:
+#   make docker
+#   make docker DOCKER_TAG=master SUBSTRA_GIT_REF=master
+#   make docker DOCKER_TAG=1.0    SUBSTRA_GIT_REF=v1.0
+#   make docker DOCKER_TAG=pr_123 SUBSTRA_GIT_REF=refs/pull/123/head
+#   make docker DOCKER_TAG=commit SUBSTRA_GIT_REF@da39a3ee5e6b4b0d3255bfef95601890afd80709
 docker:
-	docker build -f docker/Dockerfile . -t substra-tests:$(DOCKER_TAG) --build-arg SUBSTRA_VERSION=$(DOCKER_TAG_SUBSTRA)
+	docker build -f docker/Dockerfile .	-t $(DOCKER_IMG):$(DOCKER_TAG) \
+		--build-arg SUBSTRA_GIT_REPO=$(SUBSTRA_GIT_REPO) \
+		--build-arg SUBSTRA_GIT_REF=$(SUBSTRA_GIT_REF)
+

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ install:
 #   make docker DOCKER_TAG=master SUBSTRA_GIT_REF=master
 #   make docker DOCKER_TAG=1.0    SUBSTRA_GIT_REF=v1.0
 #   make docker DOCKER_TAG=pr_123 SUBSTRA_GIT_REF=refs/pull/123/head
-#   make docker DOCKER_TAG=commit SUBSTRA_GIT_REF@da39a3ee5e6b4b0d3255bfef95601890afd80709
+#   make docker DOCKER_TAG=commit SUBSTRA_GIT_REF=da39a3ee5e6b4b0d3255bfef95601890afd80709
 docker:
 	docker build -f docker/Dockerfile .	-t $(DOCKER_IMG):$(DOCKER_TAG) \
 		--build-arg SUBSTRA_GIT_REPO=$(SUBSTRA_GIT_REPO) \
 		--build-arg SUBSTRA_GIT_REF=$(SUBSTRA_GIT_REF)
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,9 @@
 ARG SUBSTRA_VERSION=latest
 FROM substra:$SUBSTRA_VERSION
 
-RUN mkdir -p /usr/src/app/substra-tests
-COPY ./requirements.txt /usr/src/app/substra-tests
-COPY ./*.yaml /usr/src/app/substra-tests/
-COPY ./Makefile /usr/src/app/substra-tests/
-COPY ./tests /usr/src/app/substra-tests/tests/
-COPY ./substratest /usr/src/app/substra-tests/substratest/
-
 WORKDIR /usr/src/app/substra-tests
-RUN pip3 install -r requirements.txt
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,12 @@
-ARG SUBSTRA_VERSION=latest
-FROM substra:$SUBSTRA_VERSION
+FROM python:3.7
 
-WORKDIR /usr/src/app/substra-tests
+WORKDIR /usr/src/app
+
+RUN pip install keyrings.alt
+
+ARG SUBSTRA_GIT_REPO
+ARG SUBSTRA_GIT_REF
+RUN pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+ARG SUBSTRA_VERSION=latest
+FROM substra:$SUBSTRA_VERSION
+
+RUN mkdir -p /usr/src/app/substra-tests
+COPY ./requirements.txt /usr/src/app/substra-tests
+COPY ./*.yaml /usr/src/app/substra-tests/
+COPY ./Makefile /usr/src/app/substra-tests/
+COPY ./tests /usr/src/app/substra-tests/tests/
+COPY ./substratest /usr/src/app/substra-tests/substratest/
+
+WORKDIR /usr/src/app/substra-tests
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
- Follow-up to https://github.com/SubstraFoundation/substra-backend/pull/154
- Companion PR: https://github.com/SubstraFoundation/substra/pull/123

### 1. Build `substra` image

```bash
~/code/substra$ make docker
docker build -f docker/Dockerfile . -t substra:latest
Step 1/9 : FROM python:3.7
[...]
Successfully tagged substra:latest
```

Note: You can specify the tag to build: `make docker DOCKER_TAG=my-version`

### 2. Build `substra-tests` image

```bash
~/code/substra-tests$ make docker
docker build -f docker/Dockerfile . -t substra-tests:latest --build-arg SUBSTRA_VERSION=latest
Step 1/10 : ARG SUBSTRA_VERSION=latest
[...]
Successfully tagged substra-tests:latest
```

Note: 
- You can specify the tag to build: `make docker DOCKER_TAG=my-version`
- You can specify the base `substra` image tag to use: `make docker DOCKER_TAG_SUBSTRA=my-version`

### 3. Run the tests

```bash
$ docker run -it substra-tests:latest bash
root@36dbccf952d0:/usr/src/app/substra-tests# pytest -rs -q tests/test_execution.py -k test_tuples_execution_on_same_node
.                                                                                                                                                                                                    [100%]
1 passed, 10 deselected in 12.55s
```