### PR TITLE
Split session object into client and state (2)

### DIFF
--- a/substratest/__init__.py
+++ b/substratest/__init__.py
@@ -1,11 +1,11 @@
 """Substra tester package."""
 from . import utils, factory
 from .factory import AssetsFactory
-from .client import Session
+from .client import Client
 
 __all__ = [
     'factory',
     'utils',
     'AssetsFactory',
-    'Session',
+    'Client',
 ]

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -8,7 +8,7 @@ from . import assets
 DATASET_DOWNLOAD_FILENAME = 'opener.py'
 
 
-class Session:
+class Client:
     """Client to interact with a Node of Substra.
 
     Parses responses from server to return Asset instances.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,13 +57,13 @@ class _TestAssets:
 @dataclasses.dataclass
 class Network:
     options: settings.Options
-    sessions: typing.List[sbt.Client] = dataclasses.field(default_factory=list)
+    clients: typing.List[sbt.Client] = dataclasses.field(default_factory=list)
 
 
 def _get_network():
     """Create network instance from settings."""
     cfg = settings.load()
-    sessions = [sbt.Client(
+    clients = [sbt.Client(
         node_name=n.name,
         node_id=n.msp_id,
         address=n.address,
@@ -72,7 +72,7 @@ def _get_network():
     ) for n in cfg.nodes]
     return Network(
         options=cfg.options,
-        sessions=sessions,
+        clients=clients,
     )
 
 
@@ -120,43 +120,43 @@ def global_execution_env():
     factory_name = f"{TESTS_RUN_UUID}_global"
 
     with sbt.AssetsFactory(name=factory_name) as f:
-        for sess in n.sessions:
+        for client in n.clients:
 
             # create dataset
             spec = f.create_dataset()
-            dataset = sess.add_dataset(spec)
+            dataset = client.add_dataset(spec)
 
             # create train data samples
             for i in range(4):
                 spec = f.create_data_sample(datasets=[dataset], test_only=False)
-                sess.add_data_sample(spec)
+                client.add_data_sample(spec)
 
             # create test data sample
             spec = f.create_data_sample(datasets=[dataset], test_only=True)
-            test_data_sample = sess.add_data_sample(spec)
+            test_data_sample = client.add_data_sample(spec)
 
             # reload datasets (to ensure they are properly linked with the created data samples)
-            dataset = sess.get_dataset(dataset.key)
+            dataset = client.get_dataset(dataset.key)
             assets._datasets.append(dataset)
 
             # create objective
             spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
-            objective = sess.add_objective(spec)
+            objective = client.add_objective(spec)
             assets._objectives.append(objective)
 
         yield f, assets, n
 
 
 @pytest.fixture
-def session_1(network):
+def client_1(network):
     """Client fixture (first node)."""
-    return network.sessions[0]
+    return network.clients[0]
 
 
 @pytest.fixture
-def session_2(network):
+def client_2(network):
     """Client fixture (second node)."""
-    return network.sessions[1]
+    return network.clients[1]
 
 
 @pytest.fixture
@@ -167,6 +167,6 @@ def node_cfg():
 
 
 @pytest.fixture
-def session(network):
+def client(network):
     """Client fixture (first node)."""
-    return network.sessions[0]
+    return network.clients[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,10 +116,11 @@ def global_execution_env():
     Returns a tuple (factory, assets, Network).
     """
     n = _get_network()
-    assets = _TestAssets()
     factory_name = f"{TESTS_RUN_UUID}_global"
 
     with sbt.AssetsFactory(name=factory_name) as f:
+        datasets = []
+        objectives = []
         for client in n.clients:
 
             # create dataset
@@ -137,13 +138,14 @@ def global_execution_env():
 
             # reload datasets (to ensure they are properly linked with the created data samples)
             dataset = client.get_dataset(dataset.key)
-            assets._datasets.append(dataset)
+            datasets.append(dataset)
 
             # create objective
             spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
             objective = client.add_objective(spec)
-            assets._objectives.append(objective)
+            objectives.append(objective)
 
+        assets = _TestAssets(datasets=datasets, objectives=objectives)
         yield f, assets, n
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -15,8 +15,9 @@ def test_tuples_execution_on_same_node(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
-    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
+    objective = initial_assets.objectives[0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -107,8 +108,11 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
     session_1 = network.sessions[0]
     session_2 = network.sessions[1]
 
-    objective_1 = [o for o in initial_assets.objectives if o.owner == session_1.node_id][0]
-    dataset_2 = [d for d in initial_assets.datasets if d.owner == session_2.node_id][0]
+    initial_assets_1 = initial_assets.filter_by(session_1.node_id)
+    initial_assets_2 = initial_assets.filter_by(session_2.node_id)
+
+    objective_1 = initial_assets_1.objectives[0]
+    dataset_2 = initial_assets_2.datasets[0]
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)
@@ -137,7 +141,8 @@ def test_traintuple_execution_failure(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = session.add_algo(spec)
@@ -158,7 +163,8 @@ def test_composite_traintuple_execution_failure(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
 
     spec = factory.create_composite_algo(py_script=sbt.factory.INVALID_COMPOSITE_ALGO_SCRIPT)
     algo = session.add_composite_algo(spec)
@@ -180,7 +186,8 @@ def test_aggregatetuple_execution_failure(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
 
     spec = factory.create_composite_algo()
     composite_algo = session.add_composite_algo(spec)
@@ -217,8 +224,9 @@ def test_composite_traintuples_execution(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
-    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
+    objective = initial_assets.objectives[0]
 
     spec = factory.create_composite_algo()
     algo = session.add_composite_algo(spec)
@@ -271,7 +279,8 @@ def test_aggregatetuple(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
     train_data_sample_keys = dataset.train_data_sample_keys[:number_of_traintuples_to_aggregate]
 
     spec = factory.create_algo()
@@ -403,7 +412,8 @@ def test_aggregate_composite_traintuples(global_execution_env):
     # username/password are not available in the settings files.
 
     session = sessions[0]
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
     algo = session.add_algo(spec)
 
     spec = factory.create_traintuple(
@@ -465,7 +475,8 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
 
     py_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(retry_algo_snippet_toreplace, retry_snippet_replacement)
     spec = factory.create_algo(py_script)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -13,14 +13,14 @@ from . import settings
 def test_tuples_execution_on_same_node(global_execution_env):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     objective = initial_assets.objectives[0]
 
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     # create traintuple
     spec = factory.create_traintuple(
@@ -28,18 +28,18 @@ def test_tuples_execution_on_same_node(global_execution_env):
         dataset=dataset,
         data_samples=dataset.train_data_sample_keys,
     )
-    traintuple = session.add_traintuple(spec).future().wait()
+    traintuple = client.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.done
     assert traintuple.out_model is not None
 
     # check we cannot add twice the same traintuple
     with pytest.raises(substra.exceptions.AlreadyExists):
-        session.add_traintuple(spec)
+        client.add_traintuple(spec)
 
     # create testtuple
     # don't create it before to avoid MVCC errors
     spec = factory.create_testtuple(objective=objective, traintuple=traintuple)
-    testtuple = session.add_testtuple(spec).future().wait()
+    testtuple = client.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
 
     # add a traintuple depending on first traintuple
@@ -49,7 +49,7 @@ def test_tuples_execution_on_same_node(global_execution_env):
         data_samples=dataset.train_data_sample_keys,
         traintuples=[traintuple],
     )
-    traintuple = session.add_traintuple(spec).future().wait()
+    traintuple = client.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.done
     assert len(traintuple.in_models) == 1
 
@@ -58,18 +58,18 @@ def test_tuples_execution_on_same_node(global_execution_env):
 def test_federated_learning_workflow(global_execution_env):
     """Test federated learning workflow on each node."""
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
     # create test environment
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
-    # get first dataset of each session
-    # because there is only one dataset created by session, we can get all the datasets
+    # get first dataset of each client
+    # because there is only one dataset created by client, we can get all the datasets
     datasets = initial_assets.datasets
 
     # check there is one dataset per node in the network
-    assert set([d.owner for d in datasets]) == set([s.node_id for s in network.sessions])
+    assert set([d.owner for d in datasets]) == set([s.node_id for s in network.clients])
 
     # create 1 traintuple per dataset and chain them
     traintuple = None
@@ -86,7 +86,7 @@ def test_federated_learning_workflow(global_execution_env):
             rank=rank,
             compute_plan_id=compute_plan_id,
         )
-        traintuple = session.add_traintuple(spec).future().wait()
+        traintuple = client.add_traintuple(spec).future().wait()
         assert traintuple.status == assets.Status.done
         assert traintuple.out_model is not None
         assert traintuple.tag == 'foo'
@@ -96,7 +96,7 @@ def test_federated_learning_workflow(global_execution_env):
         compute_plan_id = traintuple.compute_plan_id
 
     # check a compute plan has been created and its status is at done
-    cp = session.get_compute_plan(compute_plan_id)
+    cp = client.get_compute_plan(compute_plan_id)
     assert cp.status == assets.Status.done
 
 
@@ -105,17 +105,17 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
     factory, initial_assets, network = global_execution_env
-    session_1 = network.sessions[0]
-    session_2 = network.sessions[1]
+    client_1 = network.clients[0]
+    client_2 = network.clients[1]
 
-    initial_assets_1 = initial_assets.filter_by(session_1.node_id)
-    initial_assets_2 = initial_assets.filter_by(session_2.node_id)
+    initial_assets_1 = initial_assets.filter_by(client_1.node_id)
+    initial_assets_2 = initial_assets.filter_by(client_2.node_id)
 
     objective_1 = initial_assets_1.objectives[0]
     dataset_2 = initial_assets_2.datasets[0]
 
     spec = factory.create_algo()
-    algo_2 = session_2.add_algo(spec)
+    algo_2 = client_2.add_algo(spec)
 
     # add traintuple on node 2; should execute on node 2 (dataset located on node 2)
     spec = factory.create_traintuple(
@@ -123,36 +123,36 @@ def test_tuples_execution_on_different_nodes(global_execution_env):
         dataset=dataset_2,
         data_samples=dataset_2.train_data_sample_keys,
     )
-    traintuple = session_1.add_traintuple(spec).future().wait()
+    traintuple = client_1.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.done
     assert traintuple.out_model is not None
-    assert traintuple.dataset.worker == session_2.node_id
+    assert traintuple.dataset.worker == client_2.node_id
 
     # add testtuple; should execute on node 1 (objective dataset is located on node 1)
     spec = factory.create_testtuple(objective=objective_1, traintuple=traintuple)
-    testtuple = session_1.add_testtuple(spec).future().wait()
+    testtuple = client_1.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
-    assert testtuple.dataset.worker == session_1.node_id
+    assert testtuple.dataset.worker == client_1.node_id
 
 
 @pytest.mark.slow
 def test_traintuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     spec = factory.create_traintuple(
         algo=algo,
         dataset=dataset,
         data_samples=dataset.train_data_sample_keys,
     )
-    traintuple = session.add_traintuple(spec).future().wait(raises=False)
+    traintuple = client.add_traintuple(spec).future().wait(raises=False)
     assert traintuple.status == assets.Status.failed
     assert traintuple.out_model is None
 
@@ -161,20 +161,20 @@ def test_traintuple_execution_failure(global_execution_env):
 def test_composite_traintuple_execution_failure(global_execution_env):
     """Invalid composite algo script is causing traintuple failure."""
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
 
     spec = factory.create_composite_algo(py_script=sbt.factory.INVALID_COMPOSITE_ALGO_SCRIPT)
-    algo = session.add_composite_algo(spec)
+    algo = client.add_composite_algo(spec)
 
     spec = factory.create_composite_traintuple(
         algo=algo,
         dataset=dataset,
         data_samples=dataset.train_data_sample_keys,
     )
-    composite_traintuple = session.add_composite_traintuple(spec).future().wait(raises=False)
+    composite_traintuple = client.add_composite_traintuple(spec).future().wait(raises=False)
     assert composite_traintuple.status == assets.Status.failed
     assert composite_traintuple.out_head_model.out_model is None
     assert composite_traintuple.out_trunk_model.out_model is None
@@ -184,16 +184,16 @@ def test_composite_traintuple_execution_failure(global_execution_env):
 def test_aggregatetuple_execution_failure(global_execution_env):
     """Invalid algo script is causing traintuple failure."""
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
 
     spec = factory.create_composite_algo()
-    composite_algo = session.add_composite_algo(spec)
+    composite_algo = client.add_composite_algo(spec)
 
     spec = factory.create_aggregate_algo(py_script=sbt.factory.INVALID_AGGREGATE_ALGO_SCRIPT)
-    aggregate_algo = session.add_aggregate_algo(spec)
+    aggregate_algo = client.add_aggregate_algo(spec)
 
     composite_traintuples = []
     for i in [0, 1]:
@@ -202,16 +202,16 @@ def test_aggregatetuple_execution_failure(global_execution_env):
             dataset=dataset,
             data_samples=[dataset.train_data_sample_keys[i]],
         )
-        composite_traintuples.append(session.add_composite_traintuple(spec))
+        composite_traintuples.append(client.add_composite_traintuple(spec))
 
     spec = factory.create_aggregatetuple(
         algo=aggregate_algo,
         traintuples=composite_traintuples,
-        worker=session.node_id,
+        worker=client.node_id,
     )
-    aggregatetuple = session.add_aggregatetuple(spec).future().wait(raises=False)
+    aggregatetuple = client.add_aggregatetuple(spec).future().wait(raises=False)
     for composite_traintuple in composite_traintuples:
-        composite_traintuple = session.get_composite_traintuple(composite_traintuple.key)
+        composite_traintuple = client.get_composite_traintuple(composite_traintuple.key)
         assert composite_traintuple.status == assets.Status.done
     assert aggregatetuple.status == assets.Status.failed
     assert aggregatetuple.out_model is None
@@ -222,14 +222,14 @@ def test_composite_traintuples_execution(global_execution_env):
     """Execution of composite traintuples."""
 
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     objective = initial_assets.objectives[0]
 
     spec = factory.create_composite_algo()
-    algo = session.add_composite_algo(spec)
+    algo = client.add_composite_algo(spec)
 
     # first composite traintuple
     spec = factory.create_composite_traintuple(
@@ -237,7 +237,7 @@ def test_composite_traintuples_execution(global_execution_env):
         dataset=dataset,
         data_samples=dataset.train_data_sample_keys,
     )
-    composite_traintuple_1 = session.add_composite_traintuple(spec).future().wait()
+    composite_traintuple_1 = client.add_composite_traintuple(spec).future().wait()
     assert composite_traintuple_1.status == assets.Status.done
     assert composite_traintuple_1.out_head_model is not None
     assert composite_traintuple_1.out_head_model.out_model is not None
@@ -252,18 +252,18 @@ def test_composite_traintuples_execution(global_execution_env):
         head_traintuple=composite_traintuple_1,
         trunk_traintuple=composite_traintuple_1,
     )
-    composite_traintuple_2 = session.add_composite_traintuple(spec).future().wait()
+    composite_traintuple_2 = client.add_composite_traintuple(spec).future().wait()
     assert composite_traintuple_2.status == assets.Status.done
     assert composite_traintuple_2.out_head_model is not None
     assert composite_traintuple_2.out_trunk_model is not None
 
     # add a 'composite' testtuple
     spec = factory.create_testtuple(objective=objective, traintuple=composite_traintuple_2)
-    testtuple = session.add_testtuple(spec).future().wait()
+    testtuple = client.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
 
     # list composite traintuple
-    composite_traintuples = session.list_composite_traintuple()
+    composite_traintuples = client.list_composite_traintuple()
     composite_traintuple_keys = set([t.key for t in composite_traintuples])
     assert set([composite_traintuple_1.key, composite_traintuple_2.key]).issubset(
         composite_traintuple_keys
@@ -277,14 +277,14 @@ def test_aggregatetuple(global_execution_env):
     number_of_traintuples_to_aggregate = 3
 
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     train_data_sample_keys = dataset.train_data_sample_keys[:number_of_traintuples_to_aggregate]
 
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     # add traintuples
     traintuples = []
@@ -294,18 +294,18 @@ def test_aggregatetuple(global_execution_env):
             dataset=dataset,
             data_samples=[data_sample_key],
         )
-        traintuple = session.add_traintuple(spec).future().wait()
+        traintuple = client.add_traintuple(spec).future().wait()
         traintuples.append(traintuple)
 
     spec = factory.create_aggregate_algo()
-    aggregate_algo = session.add_aggregate_algo(spec)
+    aggregate_algo = client.add_aggregate_algo(spec)
 
     spec = factory.create_aggregatetuple(
         algo=aggregate_algo,
-        worker=session.node_id,
+        worker=client.node_id,
         traintuples=traintuples,
     )
-    aggregatetuple = session.add_aggregatetuple(spec).future().wait()
+    aggregatetuple = client.add_aggregatetuple(spec).future().wait()
     assert aggregatetuple.status == assets.Status.done
     assert len(aggregatetuple.in_models) == number_of_traintuples_to_aggregate
 
@@ -340,9 +340,9 @@ def test_aggregate_composite_traintuples(global_execution_env):
     This test refers to the model composition use case.
     """
     factory, initial_assets, network = global_execution_env
-    sessions = network.sessions
+    clients = network.clients
 
-    aggregate_worker = sessions[0].node_id
+    aggregate_worker = clients[0].node_id
     number_of_rounds = 2
 
     datasets = initial_assets.datasets
@@ -350,9 +350,9 @@ def test_aggregate_composite_traintuples(global_execution_env):
 
     # register algos on first node
     spec = factory.create_composite_algo()
-    composite_algo = sessions[0].add_composite_algo(spec)
+    composite_algo = clients[0].add_composite_algo(spec)
     spec = factory.create_aggregate_algo()
-    aggregate_algo = sessions[0].add_aggregate_algo(spec)
+    aggregate_algo = clients[0].add_aggregate_algo(spec)
 
     # launch execution
     previous_aggregatetuple = None
@@ -372,10 +372,10 @@ def test_aggregate_composite_traintuples(global_execution_env):
                 algo=composite_algo,
                 dataset=dataset,
                 data_samples=[dataset.train_data_sample_keys[0 + round_]],
-                permissions=Permissions(public=False, authorized_ids=[s.node_id for s in sessions]),
+                permissions=Permissions(public=False, authorized_ids=[s.node_id for s in clients]),
                 **kwargs,
             )
-            t = sessions[0].add_composite_traintuple(spec).future().wait()
+            t = clients[0].add_composite_traintuple(spec).future().wait()
             composite_traintuples.append(t)
 
         # create aggregate on its node
@@ -384,7 +384,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
             worker=aggregate_worker,
             traintuples=composite_traintuples,
         )
-        aggregatetuple = sessions[0].add_aggregatetuple(spec).future().wait()
+        aggregatetuple = clients[0].add_aggregatetuple(spec).future().wait()
 
         # save state of round
         previous_aggregatetuple = aggregatetuple
@@ -396,7 +396,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
             objective=objective,
             traintuple=traintuple,
         )
-        sessions[0].add_testtuple(spec).future().wait()
+        clients[0].add_testtuple(spec).future().wait()
 
     if not network.options.enable_intermediate_model_removal:
         return
@@ -411,17 +411,17 @@ def test_aggregate_composite_traintuples(global_execution_env):
     # deleted. Here, we cannot know for sure the failure reason. Unfortunately this cannot be done now as the
     # username/password are not available in the settings files.
 
-    session = sessions[0]
-    initial_assets = initial_assets.filter_by(session.node_id)
+    client = clients[0]
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     spec = factory.create_traintuple(
         algo=algo,
         dataset=dataset,
         data_samples=dataset.train_data_sample_keys,
     )
-    traintuple = session.add_traintuple(spec).future().wait()
+    traintuple = client.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.failed
 
 
@@ -473,14 +473,14 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     tools.algo.execute(TestAlgo())"""
 
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
 
     py_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(retry_algo_snippet_toreplace, retry_snippet_replacement)
     spec = factory.create_algo(py_script)
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     spec = factory.create_traintuple(
         algo=algo,
@@ -489,7 +489,7 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
         rank=0,  # make sure it's part of a compute plan, so we have access to the /sandbox/local
                  # folder (that's where we store the counter)
     )
-    traintuple = session.add_traintuple(spec).future().wait(raises=False)
+    traintuple = client.add_traintuple(spec).future().wait(raises=False)
 
     # Assuming that, on the backend, CELERY_TASK_MAX_RETRIES is set to 1, the algo
     # should be retried up to 1 time(s) (i.e. max 2 attempts in total)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -69,7 +69,7 @@ def test_federated_learning_workflow(global_execution_env):
     datasets = initial_assets.datasets
 
     # check there is one dataset per node in the network
-    assert set([d.owner for d in datasets]) == set([s.node_id for s in network.clients])
+    assert set([d.owner for d in datasets]) == set([c.node_id for c in network.clients])
 
     # create 1 traintuple per dataset and chain them
     traintuple = None
@@ -372,7 +372,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
                 algo=composite_algo,
                 dataset=dataset,
                 data_samples=[dataset.train_data_sample_keys[0 + round_]],
-                permissions=Permissions(public=False, authorized_ids=[s.node_id for s in clients]),
+                permissions=Permissions(public=False, authorized_ids=[c.node_id for c in clients]),
                 **kwargs,
             )
             t = clients[0].add_composite_traintuple(spec).future().wait()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -17,10 +17,12 @@ def test_compute_plan(global_execution_env):
     session_1 = network.sessions[0]
     session_2 = network.sessions[1]
 
-    dataset_1 = [d for d in initial_assets.datasets if d.owner == session_1.node_id][0]
-    dataset_2 = [d for d in initial_assets.datasets if d.owner == session_2.node_id][0]
+    initial_assets_1 = initial_assets.filter_by(session_1.node_id)
+    initial_assets_2 = initial_assets.filter_by(session_2.node_id)
 
-    objective_1 = [o for o in initial_assets.objectives if o.owner == session_1.node_id][0]
+    dataset_1 = initial_assets_1.datasets[0]
+    dataset_2 = initial_assets_2.datasets[0]
+    objective_1 = initial_assets_1.objectives[0]
 
     spec = factory.create_algo()
     algo_2 = session_2.add_algo(spec)
@@ -115,9 +117,10 @@ def test_compute_plan_single_session_success(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
+    objective = initial_assets.objectives[0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -174,9 +177,10 @@ def test_compute_plan_update(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
+    objective = initial_assets.objectives[0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -249,9 +253,10 @@ def test_compute_plan_single_session_failure(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = [o for o in initial_assets.objectives if o.owner == session.node_id][0]
+    objective = initial_assets.objectives[0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = session.add_algo(spec)
@@ -378,7 +383,8 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
     factory, initial_assets, network = global_execution_env
     session = network.sessions[0]
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
 
     spec = factory.create_algo()
     algo = session.add_algo(spec)
@@ -418,7 +424,8 @@ def test_execution_compute_plan_canceled(global_execution_env):
     #     compute plan with a large amount of tuples.
     nb_traintuples = 32
 
-    dataset = [d for d in initial_assets.datasets if d.owner == session.node_id][0]
+    initial_assets = initial_assets.filter_by(session.node_id)
+    dataset = initial_assets.datasets[0]
     data_sample_key = dataset.train_data_sample_keys[0]
 
     spec = factory.create_algo()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -14,18 +14,18 @@ def test_compute_plan(global_execution_env):
     - 1 testtuple executed on node 1 depending on the last traintuple
     """
     factory, initial_assets, network = global_execution_env
-    session_1 = network.sessions[0]
-    session_2 = network.sessions[1]
+    client_1 = network.clients[0]
+    client_2 = network.clients[1]
 
-    initial_assets_1 = initial_assets.filter_by(session_1.node_id)
-    initial_assets_2 = initial_assets.filter_by(session_2.node_id)
+    initial_assets_1 = initial_assets.filter_by(client_1.node_id)
+    initial_assets_2 = initial_assets.filter_by(client_2.node_id)
 
     dataset_1 = initial_assets_1.datasets[0]
     dataset_2 = initial_assets_2.datasets[0]
     objective_1 = initial_assets_1.objectives[0]
 
     spec = factory.create_algo()
-    algo_2 = session_2.add_algo(spec)
+    algo_2 = client_2.add_algo(spec)
 
     # create compute plan
     cp_spec = factory.create_compute_plan(tag='foo')
@@ -55,7 +55,7 @@ def test_compute_plan(global_execution_env):
     )
 
     # submit compute plan and wait for it to complete
-    cp_added = session_1.add_compute_plan(cp_spec)
+    cp_added = client_1.add_compute_plan(cp_spec)
     id_to_key = cp_added.id_to_key
 
     cp = cp_added.future().wait()
@@ -89,9 +89,9 @@ def test_compute_plan(global_execution_env):
     # XXX as the first two tuples have the same rank, there is currently no way to know
     #     which one will be returned first
     workers_rank_0 = set([traintuple_1.dataset.worker, traintuple_2.dataset.worker])
-    assert workers_rank_0 == set([session_1.node_id, session_2.node_id])
-    assert traintuple_3.dataset.worker == session_1.node_id
-    assert testtuple.dataset.worker == session_1.node_id
+    assert workers_rank_0 == set([client_1.node_id, client_2.node_id])
+    assert traintuple_3.dataset.worker == client_1.node_id
+    assert testtuple.dataset.worker == client_1.node_id
 
     # check mapping
     traintuple_id_1 = traintuple_spec_1.traintuple_id
@@ -105,7 +105,7 @@ def test_compute_plan(global_execution_env):
 
 
 @pytest.mark.slow
-def test_compute_plan_single_session_success(global_execution_env):
+def test_compute_plan_single_client_success(global_execution_env):
     """A compute plan with 3 traintuples and 3 associated testtuples"""
 
     # Create a compute plan with 3 steps:
@@ -115,15 +115,15 @@ def test_compute_plan_single_session_success(global_execution_env):
     # 3. traintuple + testtuple
 
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
     objective = initial_assets.objectives[0]
 
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     cp_spec = factory.create_compute_plan()
 
@@ -160,7 +160,7 @@ def test_compute_plan_single_session_success(global_execution_env):
     )
 
     # Submit compute plan and wait for it to complete
-    cp = session.add_compute_plan(cp_spec).future().wait()
+    cp = client.add_compute_plan(cp_spec).future().wait()
 
     # All the train/test tuples should succeed
     for t in cp.list_traintuple() + cp.list_testtuple():
@@ -175,15 +175,15 @@ def test_compute_plan_update(global_execution_env):
     """
 
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
     objective = initial_assets.objectives[0]
 
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     # Create a compute plan with traintuple + testtuple
 
@@ -197,7 +197,7 @@ def test_compute_plan_update(global_execution_env):
         objective=objective,
         traintuple_spec=traintuple_spec_1
     )
-    cp = session.add_compute_plan(cp_spec)
+    cp = client.add_compute_plan(cp_spec)
 
     # Update compute plan with traintuple + testtuple
 
@@ -212,7 +212,7 @@ def test_compute_plan_update(global_execution_env):
         objective=objective,
         traintuple_spec=traintuple_spec_2
     )
-    cp = session.update_compute_plan(cp_spec)
+    cp = client.update_compute_plan(cp_spec)
 
     # Update compute plan with traintuple + testtuple
 
@@ -227,10 +227,10 @@ def test_compute_plan_update(global_execution_env):
         objective=objective,
         traintuple_spec=traintuple_spec_3
     )
-    cp = session.update_compute_plan(cp_spec)
+    cp = client.update_compute_plan(cp_spec)
 
     # All the train/test tuples should succeed
-    cp = session.get_compute_plan(cp.compute_plan_id).future().wait()
+    cp = client.get_compute_plan(cp.compute_plan_id).future().wait()
     tuples = cp.list_traintuple() + cp.list_testtuple()
     assert len(tuples) == 6
     for t in tuples:
@@ -238,7 +238,7 @@ def test_compute_plan_update(global_execution_env):
 
 
 @pytest.mark.slow
-def test_compute_plan_single_session_failure(global_execution_env):
+def test_compute_plan_single_client_failure(global_execution_env):
     """In a compute plan with 3 traintuples, failing the root traintuple
     should cancel its descendents and the associated testtuples"""
 
@@ -251,15 +251,15 @@ def test_compute_plan_single_session_failure(global_execution_env):
     # Intentionally use an invalid (broken) algo.
 
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
     objective = initial_assets.objectives[0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     cp_spec = factory.create_compute_plan()
 
@@ -296,7 +296,7 @@ def test_compute_plan_single_session_failure(global_execution_env):
     )
 
     # Submit compute plan and wait for it to complete
-    cp = session.add_compute_plan(cp_spec).future().wait()
+    cp = client.add_compute_plan(cp_spec).future().wait()
 
     traintuples = cp.list_traintuple()
     testtuples = cp.list_testtuple()
@@ -312,9 +312,9 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
     Compute plan version of the `test_aggregate_composite_traintuples` method from `test_execution.py`
     """
     factory, initial_assets, network = global_execution_env
-    sessions = network.sessions
+    clients = network.clients
 
-    aggregate_worker = sessions[0].node_id
+    aggregate_worker = clients[0].node_id
     number_of_rounds = 2
 
     # register objectives, datasets, and data samples
@@ -323,9 +323,9 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
 
     # register algos on first node
     spec = factory.create_composite_algo()
-    composite_algo = sessions[0].add_composite_algo(spec)
+    composite_algo = clients[0].add_composite_algo(spec)
     spec = factory.create_aggregate_algo()
-    aggregate_algo = sessions[0].add_aggregate_algo(spec)
+    aggregate_algo = clients[0].add_aggregate_algo(spec)
 
     # launch execution
     previous_aggregatetuple_spec = None
@@ -347,7 +347,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
                 composite_algo=composite_algo,
                 dataset=dataset,
                 data_samples=[dataset.train_data_sample_keys[0 + round_]],
-                out_trunk_model_permissions=Permissions(public=False, authorized_ids=[s.node_id for s in sessions]),
+                out_trunk_model_permissions=Permissions(public=False, authorized_ids=[s.node_id for s in clients]),
                 **kwargs,
             )
             composite_traintuple_specs.append(spec)
@@ -370,7 +370,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
             traintuple_spec=composite_traintuple_spec,
         )
 
-    cp = sessions[0].add_compute_plan(cp_spec).future().wait()
+    cp = clients[0].add_compute_plan(cp_spec).future().wait()
     tuples = (cp.list_traintuple() +
               cp.list_composite_traintuple() +
               cp.list_aggregatetuple() +
@@ -381,13 +381,13 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
 
 def test_compute_plan_circular_dependency_failure(global_execution_env):
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
 
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     cp_spec = factory.create_compute_plan()
 
@@ -407,7 +407,7 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
     traintuple_spec_2.in_models_ids.append(traintuple_spec_1.id)
 
     with pytest.raises(substra.exceptions.InvalidRequest) as e:
-        session.add_compute_plan(cp_spec)
+        client.add_compute_plan(cp_spec)
 
     assert 'missing dependency among inModels IDs' in str(e.value)
 
@@ -415,7 +415,7 @@ def test_compute_plan_circular_dependency_failure(global_execution_env):
 @pytest.mark.slow
 def test_execution_compute_plan_canceled(global_execution_env):
     factory, initial_assets, network = global_execution_env
-    session = network.sessions[0]
+    client = network.clients[0]
 
     # XXX A canceled compute plan can be done if the it is canceled while it last tuples
     #     are executing on the workers. The compute plan status will in this case change
@@ -424,12 +424,12 @@ def test_execution_compute_plan_canceled(global_execution_env):
     #     compute plan with a large amount of tuples.
     nb_traintuples = 32
 
-    initial_assets = initial_assets.filter_by(session.node_id)
+    initial_assets = initial_assets.filter_by(client.node_id)
     dataset = initial_assets.datasets[0]
     data_sample_key = dataset.train_data_sample_keys[0]
 
     spec = factory.create_algo()
-    algo = session.add_algo(spec)
+    algo = client.add_algo(spec)
 
     cp_spec = factory.create_compute_plan()
     previous_traintuple = None
@@ -441,7 +441,7 @@ def test_execution_compute_plan_canceled(global_execution_env):
             in_models=[previous_traintuple] if previous_traintuple else None
         )
 
-    cp = session.add_compute_plan(cp_spec)
+    cp = client.add_compute_plan(cp_spec)
 
     # wait the first traintuple to be executed to ensure that the compute plan is launched
     # and tuples are scheduled in the celery workers
@@ -449,7 +449,7 @@ def test_execution_compute_plan_canceled(global_execution_env):
     first_traintuple = first_traintuple.future().wait()
     assert first_traintuple.status == assets.Status.done
 
-    cp = session.cancel_compute_plan(cp.compute_plan_id)
+    cp = client.cancel_compute_plan(cp.compute_plan_id)
     assert cp.status == assets.Status.canceled
 
     cp = cp.future().wait()

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -347,7 +347,7 @@ def test_compute_plan_aggregate_composite_traintuples(global_execution_env):
                 composite_algo=composite_algo,
                 dataset=dataset,
                 data_samples=[dataset.train_data_sample_keys[0 + round_]],
-                out_trunk_model_permissions=Permissions(public=False, authorized_ids=[s.node_id for s in clients]),
+                out_trunk_model_permissions=Permissions(public=False, authorized_ids=[c.node_id for c in clients]),
                 **kwargs,
             )
             composite_traintuple_specs.append(spec)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -144,7 +144,7 @@ def test_list_nodes(network, client):
     """Nodes are properly registered and list nodes returns expected nodes."""
     nodes = client.list_node()
     node_ids = [n.id for n in nodes]
-    network_node_ids = [s.node_id for s in network.clients]
+    network_node_ids = [c.node_id for c in network.clients]
     # check all nodes configured are correctly registered
     assert set(network_node_ids).issubset(set(node_ids))
 


### PR DESCRIPTION
🔗 **This Pull Request is related to the following issue: #76** 

As specified by @jmorel, there is still some work remaining on this point. He suggested the following changes:

- [x] Rename Session in Client
- [x] Remove `test_data_samples` and `train_data_samples` from Assets since they are not used anywhere
- [x] Add a `filter_by(node_id)` method to the Assets object that accepts as argument a string (or even better, a string or a Client object) and returns a new Assets object which contains all datasets/objectives whose owner is the given `node_id`
- [x] Update all tests to use this new `filter_by` method instead of list comprehensions
- [x] Make _Assets a standard class (it does not need to depend on Pydantic) and store actual assets in private properties (i.e. _objectives, _datasets) and have public getters (using @property) for them. This way the object will be effectively read-only.
