### PR TITLE
Pass factory, client & assets directly in arguments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,55 +100,6 @@ def network():
     return _get_network()
 
 
-# @pytest.fixture(scope='session')
-# def global_execution_env():
-#     """Network fixture with pre-existing assets in all nodes.
-#
-#     The following asssets will be created for each node:
-#     - 4 train data samples
-#     - 1 test data sample
-#     - 1 dataset
-#     - 1 objective
-#
-#     Network must started outside of the tests environment and the network is kept
-#     alive while running all tests.
-#
-#     Returns a tuple (factory, assets, Network).
-#     """
-#     n = _get_network()
-#     factory_name = f"{TESTS_RUN_UUID}_global"
-#
-#     with sbt.AssetsFactory(name=factory_name) as f:
-#         datasets = []
-#         objectives = []
-#         for client in n.clients:
-#
-#             # create dataset
-#             spec = f.create_dataset()
-#             dataset = client.add_dataset(spec)
-#
-#             # create train data samples
-#             for i in range(4):
-#                 spec = f.create_data_sample(datasets=[dataset], test_only=False)
-#                 client.add_data_sample(spec)
-#
-#             # create test data sample
-#             spec = f.create_data_sample(datasets=[dataset], test_only=True)
-#             test_data_sample = client.add_data_sample(spec)
-#
-#             # reload datasets (to ensure they are properly linked with the created data samples)
-#             dataset = client.get_dataset(dataset.key)
-#             datasets.append(dataset)
-#
-#             # create objective
-#             spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
-#             objective = client.add_objective(spec)
-#             objectives.append(objective)
-#
-#         assets = _TestAssets(datasets=datasets, objectives=objectives)
-#         yield f, assets, n
-
-
 @pytest.fixture(scope="session")
 def data_envs():
     """Fixture with pre-existing assets in all nodes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,18 +162,6 @@ def data_env_2(default_data_env, client_2):
 
 
 @pytest.fixture
-def default_dataset(data_env_1):
-    """Fixture with pre-existing dataset in first node."""
-    return data_env_1.datasets[0]
-
-
-@pytest.fixture
-def default_objective(data_env_1):
-    """Fixture with pre-existing objective in first node."""
-    return data_env_1.objectives[0]
-
-
-@pytest.fixture
 def default_dataset_1(data_env_1):
     """Fixture with pre-existing dataset in first node."""
     return data_env_1.datasets[0]
@@ -195,6 +183,18 @@ def default_dataset_2(data_env_2):
 def default_objective_2(data_env_2):
     """Fixture with pre-existing objective in second node."""
     return data_env_2.objectives[0]
+
+
+@pytest.fixture
+def default_dataset(default_dataset_1):
+    """Fixture with pre-existing dataset in first node."""
+    return default_dataset_1
+
+
+@pytest.fixture
+def default_objective(default_objective_1):
+    """Fixture with pre-existing objective in first node."""
+    return default_objective_1
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def pytest_configure(config):
     )
 
 
-class _TestAssets:
+class _DataEnv:
     """Test assets.
 
     Represents all the assets that have been added before the tests.
@@ -51,7 +51,7 @@ class _TestAssets:
         datasets = [d for d in self._datasets if d.owner == node_id]
         objectives = [o for o in self._objectives if o.owner == node_id]
 
-        return _TestAssets(objectives=objectives, datasets=datasets)
+        return _DataEnv(objectives=objectives, datasets=datasets)
 
 
 @dataclasses.dataclass
@@ -101,7 +101,7 @@ def network():
 
 
 @pytest.fixture(scope="session")
-def data_envs():
+def default_data_env():
     """Fixture with pre-existing assets in all nodes.
 
     The following assets will be created for each node:
@@ -145,20 +145,68 @@ def data_envs():
             objective = client.add_objective(spec)
             objectives.append(objective)
 
-        assets = _TestAssets(datasets=datasets, objectives=objectives)
+        assets = _DataEnv(datasets=datasets, objectives=objectives)
         return assets
 
 
 @pytest.fixture
-def data_envs_1(data_envs, client_1):
+def data_env_1(default_data_env, client_1):
     """Fixture with pre-existing assets in first node."""
-    return data_envs.filter_by(client_1.node_id)
+    return default_data_env.filter_by(client_1.node_id)
 
 
 @pytest.fixture
-def data_envs_2(data_envs, client_2):
+def data_env_2(default_data_env, client_2):
     """Fixture with pre-existing assets in second node."""
-    return data_envs.filter_by(client_2.node_id)
+    return default_data_env.filter_by(client_2.node_id)
+
+
+@pytest.fixture
+def default_dataset(data_env_1):
+    """Fixture with pre-existing dataset in first node."""
+    return data_env_1.datasets[0]
+
+
+@pytest.fixture
+def default_objective(data_env_1):
+    """Fixture with pre-existing objective in first node."""
+    return data_env_1.objectives[0]
+
+
+@pytest.fixture
+def default_dataset_1(data_env_1):
+    """Fixture with pre-existing dataset in first node."""
+    return data_env_1.datasets[0]
+
+
+@pytest.fixture
+def default_objective_1(data_env_1):
+    """Fixture with pre-existing objective in first node."""
+    return data_env_1.objectives[0]
+
+
+@pytest.fixture
+def default_dataset_2(data_env_2):
+    """Fixture with pre-existing dataset in second node."""
+    return data_env_2.datasets[0]
+
+
+@pytest.fixture
+def default_objective_2(data_env_2):
+    """Fixture with pre-existing objective in second node."""
+    return data_env_2.objectives[0]
+
+
+@pytest.fixture
+def default_datasets(default_data_env):
+    """Fixture with pre-existing datasets."""
+    return default_data_env.datasets
+
+
+@pytest.fixture
+def default_objectives(default_data_env):
+    """Fixture with pre-existing objectives."""
+    return default_data_env.objectives
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,60 +100,60 @@ def network():
     return _get_network()
 
 
-@pytest.fixture(scope='session')
-def global_execution_env():
-    """Network fixture with pre-existing assets in all nodes.
+# @pytest.fixture(scope='session')
+# def global_execution_env():
+#     """Network fixture with pre-existing assets in all nodes.
+#
+#     The following asssets will be created for each node:
+#     - 4 train data samples
+#     - 1 test data sample
+#     - 1 dataset
+#     - 1 objective
+#
+#     Network must started outside of the tests environment and the network is kept
+#     alive while running all tests.
+#
+#     Returns a tuple (factory, assets, Network).
+#     """
+#     n = _get_network()
+#     factory_name = f"{TESTS_RUN_UUID}_global"
+#
+#     with sbt.AssetsFactory(name=factory_name) as f:
+#         datasets = []
+#         objectives = []
+#         for client in n.clients:
+#
+#             # create dataset
+#             spec = f.create_dataset()
+#             dataset = client.add_dataset(spec)
+#
+#             # create train data samples
+#             for i in range(4):
+#                 spec = f.create_data_sample(datasets=[dataset], test_only=False)
+#                 client.add_data_sample(spec)
+#
+#             # create test data sample
+#             spec = f.create_data_sample(datasets=[dataset], test_only=True)
+#             test_data_sample = client.add_data_sample(spec)
+#
+#             # reload datasets (to ensure they are properly linked with the created data samples)
+#             dataset = client.get_dataset(dataset.key)
+#             datasets.append(dataset)
+#
+#             # create objective
+#             spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
+#             objective = client.add_objective(spec)
+#             objectives.append(objective)
+#
+#         assets = _TestAssets(datasets=datasets, objectives=objectives)
+#         yield f, assets, n
 
-    The following asssets will be created for each node:
-    - 4 train data samples
-    - 1 test data sample
-    - 1 dataset
-    - 1 objective
 
-    Network must started outside of the tests environment and the network is kept
-    alive while running all tests.
-
-    Returns a tuple (factory, assets, Network).
-    """
-    n = _get_network()
-    factory_name = f"{TESTS_RUN_UUID}_global"
-
-    with sbt.AssetsFactory(name=factory_name) as f:
-        datasets = []
-        objectives = []
-        for client in n.clients:
-
-            # create dataset
-            spec = f.create_dataset()
-            dataset = client.add_dataset(spec)
-
-            # create train data samples
-            for i in range(4):
-                spec = f.create_data_sample(datasets=[dataset], test_only=False)
-                client.add_data_sample(spec)
-
-            # create test data sample
-            spec = f.create_data_sample(datasets=[dataset], test_only=True)
-            test_data_sample = client.add_data_sample(spec)
-
-            # reload datasets (to ensure they are properly linked with the created data samples)
-            dataset = client.get_dataset(dataset.key)
-            datasets.append(dataset)
-
-            # create objective
-            spec = f.create_objective(dataset=dataset, data_samples=[test_data_sample])
-            objective = client.add_objective(spec)
-            objectives.append(objective)
-
-        assets = _TestAssets(datasets=datasets, objectives=objectives)
-        yield f, assets, n
-
-
-@pytest.fixture
-def initial_assets():
+@pytest.fixture(scope="session")
+def data_envs():
     """Fixture with pre-existing assets in all nodes.
 
-    The following asssets will be created for each node:
+    The following assets will be created for each node:
     - 4 train data samples
     - 1 test data sample
     - 1 dataset
@@ -199,15 +199,15 @@ def initial_assets():
 
 
 @pytest.fixture
-def initial_assets_1(initial_assets, client_1):
-    """Assets fixture (first node)."""
-    return initial_assets.filter_by(client_1.node_id)
+def data_envs_1(data_envs, client_1):
+    """Fixture with pre-existing assets in first node."""
+    return data_envs.filter_by(client_1.node_id)
 
 
 @pytest.fixture
-def initial_assets_2(initial_assets, client_2):
-    """Assets fixture (second node)."""
-    return initial_assets.filter_by(client_2.node_id)
+def data_envs_2(data_envs, client_2):
+    """Fixture with pre-existing assets in second node."""
+    return data_envs.filter_by(client_2.node_id)
 
 
 @pytest.fixture
@@ -233,3 +233,9 @@ def node_cfg():
 def client(network):
     """Client fixture (first node)."""
     return network.clients[0]
+
+
+@pytest.fixture
+def clients(network):
+    """Client fixture (first node)."""
+    return network.clients

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -260,8 +260,7 @@ def test_aggregatetuple(factory, client, default_dataset):
 
 
 @pytest.mark.slow
-def test_aggregate_composite_traintuples(factory, clients, default_datasets, default_objectives,
-                                         default_dataset_1, network):
+def test_aggregate_composite_traintuples(factory, network, clients, default_datasets, default_objectives):
     """Do 2 rounds of composite traintuples aggregations on multiple nodes.
 
     Compute plan details:
@@ -357,12 +356,13 @@ def test_aggregate_composite_traintuples(factory, clients, default_datasets, def
     # username/password are not available in the settings files.
 
     client = clients[0]
+    dataset = default_datasets.sort_by(client.node_id)
     algo = client.add_algo(spec)
 
     spec = factory.create_traintuple(
         algo=algo,
-        dataset=default_dataset_1,
-        data_samples=default_dataset_1.train_data_sample_keys,
+        dataset=dataset,
+        data_samples=dataset.train_data_sample_keys,
     )
     traintuple = client.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.failed

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -10,14 +10,11 @@ from . import settings
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_same_node(global_execution_env):
+def test_tuples_execution_on_same_node(factory, client, data_envs_1):
     """Execution of a traintuple, a following testtuple and a following traintuple."""
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
-    objective = initial_assets.objectives[0]
+    dataset = data_envs_1.datasets[0]
+    objective = data_envs_1.objectives[0]
 
     spec = factory.create_algo()
     algo = client.add_algo(spec)
@@ -55,10 +52,8 @@ def test_tuples_execution_on_same_node(global_execution_env):
 
 
 @pytest.mark.slow
-def test_federated_learning_workflow(global_execution_env):
+def test_federated_learning_workflow(factory, clients, client, data_envs):
     """Test federated learning workflow on each node."""
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
 
     # create test environment
     spec = factory.create_algo()
@@ -66,10 +61,10 @@ def test_federated_learning_workflow(global_execution_env):
 
     # get first dataset of each client
     # because there is only one dataset created by client, we can get all the datasets
-    datasets = initial_assets.datasets
+    datasets = data_envs.datasets
 
     # check there is one dataset per node in the network
-    assert set([d.owner for d in datasets]) == set([c.node_id for c in network.clients])
+    assert set([d.owner for d in datasets]) == set([c.node_id for c in clients])
 
     # create 1 traintuple per dataset and chain them
     traintuple = None
@@ -101,13 +96,12 @@ def test_federated_learning_workflow(global_execution_env):
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_different_nodes(factory, client_1, client_2,
-                                             initial_assets_1, initial_assets_2):
+def test_tuples_execution_on_different_nodes(factory, client_1, client_2, data_envs_1, data_envs_2):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
 
-    objective_1 = initial_assets_1.objectives[0]
-    dataset_2 = initial_assets_2.datasets[0]
+    objective_1 = data_envs_1.objectives[0]
+    dataset_2 = data_envs_2.datasets[0]
 
     spec = factory.create_algo()
     algo_2 = client_2.add_algo(spec)
@@ -131,13 +125,10 @@ def test_tuples_execution_on_different_nodes(factory, client_1, client_2,
 
 
 @pytest.mark.slow
-def test_traintuple_execution_failure(global_execution_env):
+def test_traintuple_execution_failure(factory, client, data_envs_1):
     """Invalid algo script is causing traintuple failure."""
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
+    dataset = data_envs_1.datasets[0]
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = client.add_algo(spec)
@@ -153,13 +144,10 @@ def test_traintuple_execution_failure(global_execution_env):
 
 
 @pytest.mark.slow
-def test_composite_traintuple_execution_failure(global_execution_env):
+def test_composite_traintuple_execution_failure(factory, data_envs_1, client):
     """Invalid composite algo script is causing traintuple failure."""
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
+    dataset = data_envs_1.datasets[0]
 
     spec = factory.create_composite_algo(py_script=sbt.factory.INVALID_COMPOSITE_ALGO_SCRIPT)
     algo = client.add_composite_algo(spec)
@@ -176,13 +164,10 @@ def test_composite_traintuple_execution_failure(global_execution_env):
 
 
 @pytest.mark.slow
-def test_aggregatetuple_execution_failure(global_execution_env):
+def test_aggregatetuple_execution_failure(factory, client, data_envs_1):
     """Invalid algo script is causing traintuple failure."""
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
 
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
+    dataset = data_envs_1.datasets[0]
 
     spec = factory.create_composite_algo()
     composite_algo = client.add_composite_algo(spec)
@@ -213,15 +198,11 @@ def test_aggregatetuple_execution_failure(global_execution_env):
 
 
 @pytest.mark.slow
-def test_composite_traintuples_execution(global_execution_env):
+def test_composite_traintuples_execution(factory, client, data_envs_1):
     """Execution of composite traintuples."""
 
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
-
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
-    objective = initial_assets.objectives[0]
+    dataset = data_envs_1.datasets[0]
+    objective = data_envs_1.objectives[0]
 
     spec = factory.create_composite_algo()
     algo = client.add_composite_algo(spec)
@@ -266,16 +247,12 @@ def test_composite_traintuples_execution(global_execution_env):
 
 
 @pytest.mark.slow
-def test_aggregatetuple(global_execution_env):
+def test_aggregatetuple(factory, client, data_envs_1):
     """Execution of aggregatetuple aggregating traintuples."""
 
     number_of_traintuples_to_aggregate = 3
 
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
-
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
+    dataset = data_envs_1.datasets[0]
     train_data_sample_keys = dataset.train_data_sample_keys[:number_of_traintuples_to_aggregate]
 
     spec = factory.create_algo()
@@ -306,7 +283,7 @@ def test_aggregatetuple(global_execution_env):
 
 
 @pytest.mark.slow
-def test_aggregate_composite_traintuples(global_execution_env):
+def test_aggregate_composite_traintuples(factory, clients, data_envs, network):
     """Do 2 rounds of composite traintuples aggregations on multiple nodes.
 
     Compute plan details:
@@ -334,14 +311,12 @@ def test_aggregate_composite_traintuples(global_execution_env):
 
     This test refers to the model composition use case.
     """
-    factory, initial_assets, network = global_execution_env
-    clients = network.clients
 
     aggregate_worker = clients[0].node_id
     number_of_rounds = 2
 
-    datasets = initial_assets.datasets
-    objectives = initial_assets.objectives
+    datasets = data_envs.datasets
+    objectives = data_envs.objectives
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -407,8 +382,8 @@ def test_aggregate_composite_traintuples(global_execution_env):
     # username/password are not available in the settings files.
 
     client = clients[0]
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
+    data_envs = data_envs.filter_by(client.node_id)
+    dataset = data_envs.datasets[0]
     algo = client.add_algo(spec)
 
     spec = factory.create_traintuple(
@@ -424,7 +399,7 @@ def test_aggregate_composite_traintuples(global_execution_env):
     (settings.CELERY_TASK_MAX_RETRIES, 'done'),
     (settings.CELERY_TASK_MAX_RETRIES + 1, 'failed'),
 ))
-def test_execution_retry_on_fail(fail_count, status, global_execution_env):
+def test_execution_retry_on_fail(fail_count, status, factory, client, data_envs_1):
     """Execution of a traintuple which fails on the N first tries, and suceeds on the N+1th try"""
 
     # This test ensures the compute task retry mechanism works correctly.
@@ -467,11 +442,7 @@ def test_execution_retry_on_fail(fail_count, status, global_execution_env):
     # The counter is greater than the retry count
     tools.algo.execute(TestAlgo())"""
 
-    factory, initial_assets, network = global_execution_env
-    client = network.clients[0]
-
-    initial_assets = initial_assets.filter_by(client.node_id)
-    dataset = initial_assets.datasets[0]
+    dataset = data_envs_1.datasets[0]
 
     py_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(retry_algo_snippet_toreplace, retry_snippet_replacement)
     spec = factory.create_algo(py_script)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -356,7 +356,7 @@ def test_aggregate_composite_traintuples(factory, network, clients, default_data
     # username/password are not available in the settings files.
 
     client = clients[0]
-    dataset = default_datasets.sort_by(client.node_id)
+    dataset = default_datasets[0]
     algo = client.add_algo(spec)
 
     spec = factory.create_traintuple(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -60,6 +60,9 @@ def test_federated_learning_workflow(factory, client, default_datasets):
     traintuple = None
     rank = 0
     compute_plan_id = None
+
+    # default_datasets contains datasets on each node and
+    # that has a result we can use for federated learning
     for dataset in default_datasets:
         traintuples = [traintuple] if traintuple else []
         spec = factory.create_traintuple(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -101,15 +101,10 @@ def test_federated_learning_workflow(global_execution_env):
 
 
 @pytest.mark.slow
-def test_tuples_execution_on_different_nodes(global_execution_env):
+def test_tuples_execution_on_different_nodes(factory, client_1, client_2,
+                                             initial_assets_1, initial_assets_2):
     """Execution of a traintuple on node 1 and the following testtuple on node 2."""
     # add test data samples / dataset / objective on node 1
-    factory, initial_assets, network = global_execution_env
-    client_1 = network.clients[0]
-    client_2 = network.clients[1]
-
-    initial_assets_1 = initial_assets.filter_by(client_1.node_id)
-    initial_assets_2 = initial_assets.filter_by(client_2.node_id)
 
     objective_1 = initial_assets_1.objectives[0]
     dataset_2 = initial_assets_2.datasets[0]

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -6,17 +6,13 @@ from substratest.factory import Permissions
 from substratest import assets
 
 
-def test_compute_plan(factory, client_1, client_2, data_envs_1, data_envs_2):
+def test_compute_plan(factory, client_1, client_2, default_dataset_1, default_dataset_2, default_objective_1):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
     - 1 traintuple executed on node 2
     - 1 traintuple executed on node 1 depending on previous traintuples
     - 1 testtuple executed on node 1 depending on the last traintuple
     """
-
-    dataset_1 = data_envs_1.datasets[0]
-    dataset_2 = data_envs_2.datasets[0]
-    objective_1 = data_envs_1.objectives[0]
 
     spec = factory.create_algo()
     algo_2 = client_2.add_algo(spec)
@@ -26,25 +22,25 @@ def test_compute_plan(factory, client_1, client_2, data_envs_1, data_envs_2):
 
     traintuple_spec_1 = cp_spec.add_traintuple(
         algo=algo_2,
-        dataset=dataset_1,
-        data_samples=dataset_1.train_data_sample_keys,
+        dataset=default_dataset_1,
+        data_samples=default_dataset_1.train_data_sample_keys,
     )
 
     traintuple_spec_2 = cp_spec.add_traintuple(
         algo=algo_2,
-        dataset=dataset_2,
-        data_samples=dataset_2.train_data_sample_keys,
+        dataset=default_dataset_2,
+        data_samples=default_dataset_2.train_data_sample_keys,
     )
 
     traintuple_spec_3 = cp_spec.add_traintuple(
         algo=algo_2,
-        dataset=dataset_1,
-        data_samples=dataset_1.train_data_sample_keys,
+        dataset=default_dataset_1,
+        data_samples=default_dataset_1.train_data_sample_keys,
         in_models=[traintuple_spec_1, traintuple_spec_2],
     )
 
     cp_spec.add_testtuple(
-        objective=objective_1,
+        objective=default_objective_1,
         traintuple_spec=traintuple_spec_3,
     )
 
@@ -99,7 +95,7 @@ def test_compute_plan(factory, client_1, client_2, data_envs_1, data_envs_2):
 
 
 @pytest.mark.slow
-def test_compute_plan_single_client_success(factory, client, data_envs_1):
+def test_compute_plan_single_client_success(factory, client, default_dataset, default_objective):
     """A compute plan with 3 traintuples and 3 associated testtuples"""
 
     # Create a compute plan with 3 steps:
@@ -108,9 +104,7 @@ def test_compute_plan_single_client_success(factory, client, data_envs_1):
     # 2. traintuple + testtuple
     # 3. traintuple + testtuple
 
-    dataset = data_envs_1.datasets[0]
-    data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = data_envs_1.objectives[0]
+    data_sample_1, data_sample_2, data_sample_3, _ = default_dataset.train_data_sample_keys
 
     spec = factory.create_algo()
     algo = client.add_algo(spec)
@@ -119,33 +113,33 @@ def test_compute_plan_single_client_success(factory, client, data_envs_1):
 
     traintuple_spec_1 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_1]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_1
     )
 
     traintuple_spec_2 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_2],
         in_models=[traintuple_spec_1]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_2
     )
 
     traintuple_spec_3 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_3],
         in_models=[traintuple_spec_2]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_3
     )
 
@@ -158,15 +152,13 @@ def test_compute_plan_single_client_success(factory, client, data_envs_1):
 
 
 @pytest.mark.slow
-def test_compute_plan_update(factory, client, data_envs_1):
+def test_compute_plan_update(factory, client, default_dataset, default_objective):
     """A compute plan with 3 traintuples and 3 associated testtuples.
 
     This is done by sending 3 requests (one create and two updates).
     """
 
-    dataset = data_envs_1.datasets[0]
-    data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = data_envs_1.objectives[0]
+    data_sample_1, data_sample_2, data_sample_3, _ = default_dataset.train_data_sample_keys
 
     spec = factory.create_algo()
     algo = client.add_algo(spec)
@@ -176,11 +168,11 @@ def test_compute_plan_update(factory, client, data_envs_1):
     cp_spec = factory.create_compute_plan()
     traintuple_spec_1 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_1]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_1
     )
     cp = client.add_compute_plan(cp_spec)
@@ -190,12 +182,12 @@ def test_compute_plan_update(factory, client, data_envs_1):
     cp_spec = factory.update_compute_plan(cp)
     traintuple_spec_2 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_2],
         in_models=[traintuple_spec_1]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_2
     )
     cp = client.update_compute_plan(cp_spec)
@@ -205,12 +197,12 @@ def test_compute_plan_update(factory, client, data_envs_1):
     cp_spec = factory.update_compute_plan(cp)
     traintuple_spec_3 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_3],
         in_models=[traintuple_spec_2]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_3
     )
     cp = client.update_compute_plan(cp_spec)
@@ -224,7 +216,7 @@ def test_compute_plan_update(factory, client, data_envs_1):
 
 
 @pytest.mark.slow
-def test_compute_plan_single_client_failure(factory, client, data_envs_1):
+def test_compute_plan_single_client_failure(factory, client, default_dataset, default_objective):
     """In a compute plan with 3 traintuples, failing the root traintuple
     should cancel its descendents and the associated testtuples"""
 
@@ -236,9 +228,7 @@ def test_compute_plan_single_client_failure(factory, client, data_envs_1):
     #
     # Intentionally use an invalid (broken) algo.
 
-    dataset = data_envs_1.datasets[0]
-    data_sample_1, data_sample_2, data_sample_3, _ = dataset.train_data_sample_keys
-    objective = data_envs_1.objectives[0]
+    data_sample_1, data_sample_2, data_sample_3, _ = default_dataset.train_data_sample_keys
 
     spec = factory.create_algo(py_script=sbt.factory.INVALID_ALGO_SCRIPT)
     algo = client.add_algo(spec)
@@ -247,33 +237,33 @@ def test_compute_plan_single_client_failure(factory, client, data_envs_1):
 
     traintuple_spec_1 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_1]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_1,
     )
 
     traintuple_spec_2 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_2],
         in_models=[traintuple_spec_1]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_2,
     )
 
     traintuple_spec_3 = cp_spec.add_traintuple(
         algo=algo,
-        dataset=dataset,
+        dataset=default_dataset,
         data_samples=[data_sample_3],
         in_models=[traintuple_spec_2]
     )
     cp_spec.add_testtuple(
-        objective=objective,
+        objective=default_objective,
         traintuple_spec=traintuple_spec_3,
     )
 
@@ -289,16 +279,12 @@ def test_compute_plan_single_client_failure(factory, client, data_envs_1):
 
 
 @pytest.mark.slow
-def test_compute_plan_aggregate_composite_traintuples(factory, clients, data_envs):
+def test_compute_plan_aggregate_composite_traintuples(factory, clients, default_datasets, default_objectives):
     """
     Compute plan version of the `test_aggregate_composite_traintuples` method from `test_execution.py`
     """
     aggregate_worker = clients[0].node_id
     number_of_rounds = 2
-
-    # register objectives, datasets, and data samples
-    datasets = data_envs.datasets
-    objectives = data_envs.objectives
 
     # register algos on first node
     spec = factory.create_composite_algo()
@@ -315,7 +301,7 @@ def test_compute_plan_aggregate_composite_traintuples(factory, clients, data_env
     for round_ in range(number_of_rounds):
         # create composite traintuple on each node
         composite_traintuple_specs = []
-        for index, dataset in enumerate(datasets):
+        for index, dataset in enumerate(default_datasets):
             kwargs = {}
             if previous_aggregatetuple_spec:
                 kwargs = {
@@ -343,7 +329,7 @@ def test_compute_plan_aggregate_composite_traintuples(factory, clients, data_env
         previous_composite_traintuple_specs = composite_traintuple_specs
 
     # last round: create associated testtuple
-    for composite_traintuple_spec, objective in zip(previous_composite_traintuple_specs, objectives):
+    for composite_traintuple_spec, objective in zip(previous_composite_traintuple_specs, default_objectives):
         cp_spec.add_testtuple(
             objective=objective,
             traintuple_spec=composite_traintuple_spec,
@@ -358,24 +344,22 @@ def test_compute_plan_aggregate_composite_traintuples(factory, clients, data_env
         assert t.status == assets.Status.done
 
 
-def test_compute_plan_circular_dependency_failure(factory, client, data_envs_1):
-    dataset = data_envs_1.datasets[0]
-
+def test_compute_plan_circular_dependency_failure(factory, client, default_dataset):
     spec = factory.create_algo()
     algo = client.add_algo(spec)
 
     cp_spec = factory.create_compute_plan()
 
     traintuple_spec_1 = cp_spec.add_traintuple(
-        dataset=dataset,
+        dataset=default_dataset,
         algo=algo,
-        data_samples=dataset.train_data_sample_keys
+        data_samples=default_dataset.train_data_sample_keys
     )
 
     traintuple_spec_2 = cp_spec.add_traintuple(
-        dataset=dataset,
+        dataset=default_dataset,
         algo=algo,
-        data_samples=dataset.train_data_sample_keys
+        data_samples=default_dataset.train_data_sample_keys
     )
 
     traintuple_spec_1.in_models_ids.append(traintuple_spec_2.id)
@@ -388,7 +372,7 @@ def test_compute_plan_circular_dependency_failure(factory, client, data_envs_1):
 
 
 @pytest.mark.slow
-def test_execution_compute_plan_canceled(factory, client, data_envs_1):
+def test_execution_compute_plan_canceled(factory, client, default_dataset):
     # XXX A canceled compute plan can be done if the it is canceled while it last tuples
     #     are executing on the workers. The compute plan status will in this case change
     #     from canceled to done.
@@ -396,8 +380,7 @@ def test_execution_compute_plan_canceled(factory, client, data_envs_1):
     #     compute plan with a large amount of tuples.
     nb_traintuples = 32
 
-    dataset = data_envs_1.datasets[0]
-    data_sample_key = dataset.train_data_sample_keys[0]
+    data_sample_key = default_dataset.train_data_sample_keys[0]
 
     spec = factory.create_algo()
     algo = client.add_algo(spec)
@@ -407,7 +390,7 @@ def test_execution_compute_plan_canceled(factory, client, data_envs_1):
     for _ in range(nb_traintuples):
         previous_traintuple = cp_spec.add_traintuple(
             algo=algo,
-            dataset=dataset,
+            dataset=default_dataset,
             data_samples=[data_sample_key],
             in_models=[previous_traintuple] if previous_traintuple else None
         )

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -140,11 +140,11 @@ def test_add_composite_algo(factory, client):
     assert algo == algo_copy
 
 
-def test_list_nodes(clients, client):
+def test_list_nodes(client, network):
     """Nodes are properly registered and list nodes returns expected nodes."""
     nodes = client.list_node()
     node_ids = [n.id for n in nodes]
-    network_node_ids = [c.node_id for c in clients]
+    network_node_ids = [c.node_id for c in network.clients]
     # check all nodes configured are correctly registered
     assert set(network_node_ids).issubset(set(node_ids))
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -8,9 +8,9 @@ import substratest as sbt
 from . import settings
 
 
-def test_connection_to_nodes(network):
+def test_connection_to_nodes(clients):
     """Connect to each substra nodes using the client."""
-    for client in network.clients:
+    for client in clients:
         client.list_algo()
 
 
@@ -140,11 +140,11 @@ def test_add_composite_algo(factory, client):
     assert algo == algo_copy
 
 
-def test_list_nodes(network, client):
+def test_list_nodes(clients, client):
     """Nodes are properly registered and list nodes returns expected nodes."""
     nodes = client.list_node()
     node_ids = [n.id for n in nodes]
-    network_node_ids = [c.node_id for c in network.clients]
+    network_node_ids = [c.node_id for c in clients]
     # check all nodes configured are correctly registered
     assert set(network_node_ids).issubset(set(node_ids))
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -161,12 +161,12 @@ def test_permissions_denied_process(factory, client_1, client_2):
 
 @pytest.mark.slow
 @pytest.mark.xfail(reason='permission check not yet implemented in the backend')
-def test_permissions_denied_model_process(factory, clients, client_1, client_2):
+def test_permissions_denied_model_process(factory, client_1, client_2, network):
     # setup
 
     datasets = []
     algos = []
-    for client in clients[:2]:
+    for client in network.clients[:2]:
         # dataset
         spec = factory.create_dataset(permissions=Permissions(public=False, authorized_ids=[]))
         dataset = client.add_dataset(spec)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -25,9 +25,9 @@ def test_permission_creation(is_public, factory, client):
     Permissions(public=False, authorized_ids=[MSP_IDS[0]]),
     Permissions(public=False, authorized_ids=[MSP_IDS[1]]),
 ])
-def test_get_metadata(permissions, factory, network):
+def test_get_metadata(permissions, factory, clients):
     """Test get metadata assets with various permissions."""
-    clients = network.clients[:2]
+    clients = clients[:2]
 
     # add 1 dataset per node
     datasets = []
@@ -127,10 +127,7 @@ def test_merge_permissions(permissions_1, permissions_2, expected_permissions,
     assert set(tuple_permissions.authorized_ids) == set(expected_permissions.authorized_ids)
 
 
-def test_permissions_denied_process(factory, network):
-    client_1 = network.clients[0]
-    client_2 = network.clients[1]
-
+def test_permissions_denied_process(factory, client_1, client_2):
     # setup data
 
     spec = factory.create_dataset(permissions=Permissions(public=False, authorized_ids=[]))
@@ -164,15 +161,12 @@ def test_permissions_denied_process(factory, network):
 
 @pytest.mark.slow
 @pytest.mark.xfail(reason='permission check not yet implemented in the backend')
-def test_permissions_denied_model_process(factory, network):
-    client_1 = network.clients[0]
-    client_2 = network.clients[1]
-
+def test_permissions_denied_model_process(factory, clients, client_1, client_2):
     # setup
 
     datasets = []
     algos = []
-    for client in network.clients[:2]:
+    for client in clients[:2]:
         # dataset
         spec = factory.create_dataset(permissions=Permissions(public=False, authorized_ids=[]))
         dataset = client.add_dataset(spec)
@@ -214,7 +208,7 @@ def test_permissions_denied_model_process(factory, network):
 
 
 @pytest.mark.skipif(len(MSP_IDS) < 3, reason='requires at least 3 nodes')
-def test_merge_permissions_denied_process(factory, network):
+def test_merge_permissions_denied_process(factory, clients):
     """Test to process asset with merged permissions from 2 other nodes
 
     - dataset and objectives located on node 1
@@ -223,9 +217,9 @@ def test_merge_permissions_denied_process(factory, network):
     - failed attempt to create testtuple using this traintuple from node 3
     """
     # define clients one and for all
-    client_1 = network.clients[0]
-    client_2 = network.clients[1]
-    client_3 = network.clients[2]
+    client_1 = clients[0]
+    client_2 = clients[1]
+    client_3 = clients[2]
 
     permissions_list = [(
         Permissions(public=False, authorized_ids=[MSP_IDS[1], MSP_IDS[2]]),
@@ -278,10 +272,7 @@ def test_merge_permissions_denied_process(factory, network):
             client_3.add_testtuple(spec)
 
 
-def test_permissions_denied_head_model_process(network, factory):
-    client_1 = network.clients[0]
-    client_2 = network.clients[1]
-
+def test_permissions_denied_head_model_process(factory, client_1, client_2):
     # setup data
 
     datasets = []


### PR DESCRIPTION
Currently, there are a few lines at the beginning of each test which allows to get the following variables:
• `factory` - *used for the `create_asset` methods*
• `initial_assets` - *initial assets used in the test*
• `network` - *used to get the client(s)*
They are set using this line:
```py
factory, initial_assets, network = global_execution_env
```  

The goal of this PR would be to pass directly these variable into the test, instead of getting them into. It avoids duplicated code and makes it easier to read.