### PR TITLE
Add user metadata

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -201,7 +201,7 @@ class Dataset(_Asset):
     name: str
     owner: str
     objective_key: str
-    metadata: typing.Dict[str, str] = None
+    metadata: typing.Dict[str, str]
     permissions: Permissions
     # the JSON data returned by list_dataset doesn't include the following keys at all
     # they are only included in the result of get_dataset
@@ -337,7 +337,7 @@ class Testtuple(_Asset, _FutureMixin):
     certified: bool
     rank: int
     tag: str
-    metadata: typing.Dict[str, str] = None
+    metadata: typing.Dict[str, str]
     log: str
 
 
@@ -350,7 +350,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
     testtuple_keys: typing.List[str]
     id_to_key: typing.Dict[str, str]
     tag: str
-    metadata: typing.Dict[str, str] = None
+    metadata: typing.Dict[str, str]
 
     def __init__(self, *args, **kwargs):
         kwargs['traintuple_keys'] = kwargs.get('traintuple_keys') or []

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -350,7 +350,6 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
     testtuple_keys: typing.List[str]
     id_to_key: typing.Dict[str, str]
     tag: str
-    metadata: typing.Dict[str, str]
 
     def __init__(self, *args, **kwargs):
         kwargs['traintuple_keys'] = kwargs.get('traintuple_keys') or []

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -299,7 +299,7 @@ class Aggregatetuple(_Asset, _FutureMixin):
     tag: str
     metadata: typing.Dict[str, str]
     log: str
-    in_models: typing.List[InModel]
+    in_models: typing.List[InModel] = None
     out_model: typing.Optional[OutModel]
 
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -201,6 +201,7 @@ class Dataset(_Asset):
     name: str
     owner: str
     objective_key: str
+    metadata: typing.Dict[str, str] = None
     permissions: Permissions
     # the JSON data returned by list_dataset doesn't include the following keys at all
     # they are only included in the result of get_dataset
@@ -212,6 +213,7 @@ class _Algo(_Asset):
     key: str
     name: str
     owner: str
+    metadata: typing.Dict[str, str]
     permissions: Permissions
 
 
@@ -231,6 +233,7 @@ class Objective(_Asset):
     key: str
     name: str
     owner: str
+    metadata: typing.Dict[str, str]
     permissions: Permissions
     test_dataset: typing.Optional[ObjectiveDataset]
 
@@ -279,6 +282,7 @@ class Traintuple(_Asset, _FutureMixin):
     compute_plan_id: str
     rank: int
     tag: str
+    metadata: typing.Dict[str, str]
     log: str
     in_models: typing.Optional[typing.List[InModel]]
     out_model: typing.Optional[OutModel]
@@ -293,6 +297,7 @@ class Aggregatetuple(_Asset, _FutureMixin):
     compute_plan_id: str
     rank: int
     tag: str
+    metadata: typing.Dict[str, str]
     log: str
     in_models: typing.List[InModel]
     out_model: typing.Optional[OutModel]
@@ -316,6 +321,7 @@ class CompositeTraintuple(_Asset, _FutureMixin):
     compute_plan_id: str
     rank: int
     tag: str
+    metadata: typing.Dict[str, str]
     log: str
     in_head_model: typing.Optional[InModel]
     in_trunk_model: typing.Optional[InModel]
@@ -331,6 +337,7 @@ class Testtuple(_Asset, _FutureMixin):
     certified: bool
     rank: int
     tag: str
+    metadata: typing.Dict[str, str] = None
     log: str
 
 
@@ -343,6 +350,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
     testtuple_keys: typing.List[str]
     id_to_key: typing.Dict[str, str]
     tag: str
+    metadata: typing.Dict[str, str] = None
 
     def __init__(self, *args, **kwargs):
         kwargs['traintuple_keys'] = kwargs.get('traintuple_keys') or []

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -183,7 +183,7 @@ class DatasetSpec(_Spec):
     data_opener: str
     type: str
     description: str
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     permissions: Permissions = None
     objective_key: str = None
 
@@ -203,7 +203,7 @@ class ObjectiveSpec(_Spec):
     metrics: str
     test_data_sample_keys: typing.List[str]
     test_data_manager_key: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     permissions: Permissions = None
 
 
@@ -211,7 +211,7 @@ class _AlgoSpec(_Spec):
     name: str
     description: str
     file: str
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     permissions: Permissions = None
 
 
@@ -233,7 +233,7 @@ class TraintupleSpec(_Spec):
     train_data_sample_keys: typing.List[str]
     in_models_keys: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     compute_plan_id: str = None
     rank: int = None
 
@@ -243,7 +243,7 @@ class AggregatetupleSpec(_Spec):
     worker: str
     in_models_keys: typing.List[str]
     tag: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     compute_plan_id: str = None
     rank: int = None
 
@@ -255,7 +255,7 @@ class CompositeTraintupleSpec(_Spec):
     in_head_model_key: str = None
     in_trunk_model_key: str = None
     tag: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     compute_plan_id: str = None
     out_trunk_model_permissions: PrivatePermissions
     rank: int = None
@@ -267,7 +267,7 @@ class TesttupleSpec(_Spec):
     tag: str = None
     data_manager_key: str = None
     test_data_sample_keys: typing.List[str] = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
 
 
 class ComputePlanTraintupleSpec(_Spec):
@@ -277,7 +277,7 @@ class ComputePlanTraintupleSpec(_Spec):
     traintuple_id: str
     in_models_ids: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
 
     @property
     def id(self):
@@ -290,7 +290,7 @@ class ComputePlanAggregatetupleSpec(_Spec):
     worker: str
     in_models_ids: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
 
     @property
     def id(self):
@@ -305,7 +305,7 @@ class ComputePlanCompositeTraintupleSpec(_Spec):
     in_head_model_id: str = None
     in_trunk_model_id: str = None
     tag: str = None
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
     out_trunk_model_permissions: Permissions
 
     @property
@@ -317,7 +317,7 @@ class ComputePlanTesttupleSpec(_Spec):
     objective_key: str
     traintuple_id: str
     tag: str
-    metadata: typing.Dict = None
+    metadata: typing.Dict[str, str] = None
 
 
 def _get_key(obj, field='key'):

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -388,9 +388,8 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             train_data_sample_keys=_get_keys(data_samples),
             in_head_model_id=in_head_model.id if in_head_model else None,
             in_trunk_model_id=in_trunk_model.id if in_trunk_model else None,
-            out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_MODEL_PERMISSIONS,
-            tag=tag,
-            metadata=metadata
+            out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_TRUNK_MODEL_PERMISSIONS,
+            tag=tag
         )
         self.composite_traintuples.append(spec)
         return spec

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -277,7 +277,6 @@ class ComputePlanTraintupleSpec(_Spec):
     traintuple_id: str
     in_models_ids: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict[str, str] = None
 
     @property
     def id(self):
@@ -290,7 +289,6 @@ class ComputePlanAggregatetupleSpec(_Spec):
     worker: str
     in_models_ids: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict[str, str] = None
 
     @property
     def id(self):
@@ -305,7 +303,6 @@ class ComputePlanCompositeTraintupleSpec(_Spec):
     in_head_model_id: str = None
     in_trunk_model_id: str = None
     tag: str = None
-    metadata: typing.Dict[str, str] = None
     out_trunk_model_permissions: Permissions
 
     @property
@@ -317,7 +314,6 @@ class ComputePlanTesttupleSpec(_Spec):
     objective_key: str
     traintuple_id: str
     tag: str
-    metadata: typing.Dict[str, str] = None
 
 
 def _get_key(obj, field='key'):

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -183,7 +183,7 @@ class DatasetSpec(_Spec):
     data_opener: str
     type: str
     description: str
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     permissions: Permissions = None
     objective_key: str = None
 
@@ -203,7 +203,7 @@ class ObjectiveSpec(_Spec):
     metrics: str
     test_data_sample_keys: typing.List[str]
     test_data_manager_key: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     permissions: Permissions = None
 
 
@@ -211,7 +211,7 @@ class _AlgoSpec(_Spec):
     name: str
     description: str
     file: str
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     permissions: Permissions = None
 
 
@@ -233,7 +233,7 @@ class TraintupleSpec(_Spec):
     train_data_sample_keys: typing.List[str]
     in_models_keys: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     compute_plan_id: str = None
     rank: int = None
 
@@ -243,7 +243,7 @@ class AggregatetupleSpec(_Spec):
     worker: str
     in_models_keys: typing.List[str]
     tag: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     compute_plan_id: str = None
     rank: int = None
 
@@ -255,7 +255,7 @@ class CompositeTraintupleSpec(_Spec):
     in_head_model_key: str = None
     in_trunk_model_key: str = None
     tag: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     compute_plan_id: str = None
     out_trunk_model_permissions: PrivatePermissions
     rank: int = None
@@ -267,7 +267,7 @@ class TesttupleSpec(_Spec):
     tag: str = None
     data_manager_key: str = None
     test_data_sample_keys: typing.List[str] = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
 
 
 class ComputePlanTraintupleSpec(_Spec):
@@ -277,7 +277,7 @@ class ComputePlanTraintupleSpec(_Spec):
     traintuple_id: str
     in_models_ids: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
 
     @property
     def id(self):
@@ -290,7 +290,7 @@ class ComputePlanAggregatetupleSpec(_Spec):
     worker: str
     in_models_ids: typing.List[str] = None
     tag: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
 
     @property
     def id(self):
@@ -305,7 +305,7 @@ class ComputePlanCompositeTraintupleSpec(_Spec):
     in_head_model_id: str = None
     in_trunk_model_id: str = None
     tag: str = None
-    metadata: typing.Dict
+    metadata: typing.Dict = None
     out_trunk_model_permissions: Permissions
 
     @property
@@ -317,7 +317,7 @@ class ComputePlanTesttupleSpec(_Spec):
     objective_key: str
     traintuple_id: str
     tag: str
-    metadata: typing.Dict
+    metadata: typing.Dict = None
 
 
 def _get_key(obj, field='key'):

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -340,7 +340,7 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
     aggregatetuples: typing.List[ComputePlanAggregatetupleSpec]
     testtuples: typing.List[ComputePlanTesttupleSpec]
 
-    def add_traintuple(self, algo, dataset, data_samples, in_models=None, tag='', metadata=None):
+    def add_traintuple(self, algo, dataset, data_samples, in_models=None, tag=''):
         in_models = in_models or []
         spec = ComputePlanTraintupleSpec(
             algo_key=algo.key,
@@ -348,13 +348,12 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             data_manager_key=dataset.key,
             train_data_sample_keys=_get_keys(data_samples),
             in_models_ids=[t.id for t in in_models],
-            tag=tag,
-            metadata=metadata,
+            tag=tag
         )
         self.traintuples.append(spec)
         return spec
 
-    def add_aggregatetuple(self, aggregate_algo, worker, in_models=None, tag='', metadata=None):
+    def add_aggregatetuple(self, aggregate_algo, worker, in_models=None, tag=''):
         in_models = in_models or []
 
         for t in in_models:
@@ -365,15 +364,14 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             algo_key=aggregate_algo.key,
             worker=worker,
             in_models_ids=[t.id for t in in_models],
-            tag=tag,
-            metadata=metadata
+            tag=tag
         )
         self.aggregatetuples.append(spec)
         return spec
 
     def add_composite_traintuple(self, composite_algo, dataset=None, data_samples=None,
                                  in_head_model=None, in_trunk_model=None,
-                                 out_trunk_model_permissions=None, tag='', metadata=None):
+                                 out_trunk_model_permissions=None, tag=''):
         data_samples = data_samples or []
 
         if in_head_model and in_trunk_model:
@@ -390,19 +388,18 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             train_data_sample_keys=_get_keys(data_samples),
             in_head_model_id=in_head_model.id if in_head_model else None,
             in_trunk_model_id=in_trunk_model.id if in_trunk_model else None,
-            out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_TRUNK_MODEL_PERMISSIONS,
+            out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_MODEL_PERMISSIONS,
             tag=tag,
             metadata=metadata
         )
         self.composite_traintuples.append(spec)
         return spec
 
-    def add_testtuple(self, objective, traintuple_spec, tag=None, metadata=None):
+    def add_testtuple(self, objective, traintuple_spec, tag=None):
         spec = ComputePlanTesttupleSpec(
             objective_key=objective.key,
             traintuple_id=traintuple_spec.id,
-            tag=tag or '',
-            metadata=metadata
+            tag=tag or ''
         )
         self.testtuples.append(spec)
         return spec

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -370,7 +370,7 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             worker=worker,
             in_models_ids=[t.id for t in in_models],
             tag=tag,
-            metadata=metadata or {}
+            metadata=metadata
         )
         self.aggregatetuples.append(spec)
         return spec
@@ -396,7 +396,7 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             in_trunk_model_id=in_trunk_model.id if in_trunk_model else None,
             out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_TRUNK_MODEL_PERMISSIONS,
             tag=tag,
-            metadata=metadata or {}
+            metadata=metadata
         )
         self.composite_traintuples.append(spec)
         return spec
@@ -406,7 +406,7 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             objective_key=objective.key,
             traintuple_id=traintuple_spec.id,
             tag=tag or '',
-            metadata=metadata or {}
+            metadata=metadata
         )
         self.testtuples.append(spec)
         return spec

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -20,9 +20,11 @@ def test_tuples_execution_on_same_node(factory, client, default_dataset, default
         algo=algo,
         dataset=default_dataset,
         data_samples=default_dataset.train_data_sample_keys,
+        metadata={"foo": "bar"}
     )
     traintuple = client.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.done
+    assert traintuple.metadata == {"foo": "bar"}
     assert traintuple.out_model is not None
 
     # check we cannot add twice the same traintuple
@@ -41,9 +43,11 @@ def test_tuples_execution_on_same_node(factory, client, default_dataset, default
         dataset=default_dataset,
         data_samples=default_dataset.train_data_sample_keys,
         traintuples=[traintuple],
+        metadata=None
     )
     traintuple = client.add_traintuple(spec).future().wait()
     assert traintuple.status == assets.Status.done
+    assert traintuple.metadata == {}
     assert len(traintuple.in_models) == 1
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -179,28 +179,24 @@ def test_metadata(factory, client, asset_name, metadata, metadata_output):
     'composite_algo',
 ])
 @pytest.mark.parametrize('metadata', [
-    ({'foo': {"bar": "foo"}}),
-    ({too_long: "bar"}),
-    ({"foo": too_long}),
+    'foo',
+    {'foo': {"bar": "foo"}},
+    {too_long: "bar"},
+    {"foo": too_long},
 ])
 def test_invalid_metadata(factory, client, asset_name, metadata):
     method_create = getattr(factory, f"create_{asset_name}")
-    method_add = getattr(client, f"add_{asset_name}")
     method_sdk_add = getattr(client._client, f"add_{asset_name}")
 
     spec = method_create()
     spec_dict = spec.dict()
-    spec_dict['metadata'] = 'foo'
+    spec_dict['metadata'] = metadata
 
     with pytest.raises(substra.exceptions.InvalidRequest):
         method_sdk_add(spec_dict)
 
-    spec = method_create(metadata=metadata)
-    with pytest.raises(substra.exceptions.InvalidRequest):
-        method_add(spec)
 
-
-@pytest.mark.parametrize('asset_name, algo_type', [
+@pytest.mark.parametrize('asset_name,algo_type', [
     ('traintuple', 'algo'),
     ('composite_traintuple', 'composite_algo'),
 ])
@@ -233,13 +229,14 @@ def test_metadata_traintuple(factory, client, asset_name, algo_type, default_dat
     ('composite_traintuple', 'composite_algo'),
 ])
 @pytest.mark.parametrize('metadata', [
-    ({'foo': {"bar": "foo"}}),
-    ({too_long: "bar"}),
-    ({"foo": too_long}),
+    'foo',
+    {'foo': {"bar": "foo"}},
+    {too_long: "bar"},
+    {"foo": too_long},
 ])
 def test_metadata_invalid_traintuple(factory, client, asset_name, algo_type, default_dataset, metadata):
     method_create = getattr(factory, f"create_{asset_name}")
-    method_add = getattr(client, f"add_{asset_name}")
+    method_sdk_add = getattr(client._client, f"add_{asset_name}")
 
     algo_create = getattr(factory, f"create_{algo_type}")
     algo_add = getattr(client, f"add_{algo_type}")
@@ -251,10 +248,12 @@ def test_metadata_invalid_traintuple(factory, client, asset_name, algo_type, def
         algo=algo,
         dataset=default_dataset,
         data_samples=default_dataset.train_data_sample_keys,
-        metadata=metadata
     )
+    spec_dict = spec.dict()
+    spec_dict['metadata'] = metadata
+
     with pytest.raises(substra.exceptions.InvalidRequest):
-        method_add(spec)
+        method_sdk_add(spec_dict)
 
 
 @pytest.mark.parametrize('metadata,metadata_output', [
@@ -277,22 +276,25 @@ def test_metadata_aggregatetuple(factory, client, default_dataset, metadata, met
 
 
 @pytest.mark.parametrize('metadata', [
-    ({'foo': {"bar": "foo"}}),
-    ({too_long: "bar"}),
-    ({"foo": too_long}),
+    'foo',
+    {'foo': {"bar": "foo"}},
+    {too_long: "bar"},
+    {"foo": too_long},
 ])
 def test_metadata_invalid_aggregatetuple(factory, client, default_dataset, metadata):
     aggregate_algo_spec = factory.create_aggregate_algo()
     aggregate_algo = client.add_aggregate_algo(aggregate_algo_spec)
+
     spec = factory.create_aggregatetuple(
         algo=aggregate_algo,
         worker=client.node_id,
         traintuples=[],
-        metadata={"foo": "bar"}
     )
+    spec_dict = spec.dict()
+    spec_dict['metadata'] = metadata
 
     with pytest.raises(substra.exceptions.InvalidRequest):
-        client.add_aggregatetuple(spec)
+        client._client.add_aggregatetuple(spec_dict)
 
 
 def test_add_algo(factory, client):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -189,63 +189,6 @@ def test_asset_with_invalid_metadata(factory, client, asset_name, metadata):
         add_asset(spec)
 
 
-@pytest.mark.parametrize('asset_name,algo_type', [
-    ('traintuple', 'algo'),
-    ('composite_traintuple', 'composite_algo'),
-])
-@pytest.mark.parametrize('metadata,metadata_output', [
-    ({'foo': 'bar'}, {'foo': 'bar'}),
-    (None, {}),
-    ({}, {}),
-])
-def test_traintuple_with_metadata(factory, client, asset_name, algo_type, default_dataset, metadata, metadata_output):
-    create_spec = getattr(factory, f"create_{asset_name}")
-    add_asset = getattr(client, f"add_{asset_name}")
-
-    algo_create = getattr(factory, f"create_{algo_type}")
-    algo_add = getattr(client, f"add_{algo_type}")
-
-    algo_spec = algo_create()
-    algo = algo_add(algo_spec)
-    spec = create_spec(
-        algo=algo,
-        dataset=default_dataset,
-        data_samples=default_dataset.train_data_sample_keys,
-        metadata=metadata
-    )
-    asset = add_asset(spec)
-    assert asset.metadata == metadata_output
-
-
-@pytest.mark.parametrize('asset_name, algo_type', [
-    ('traintuple', 'algo'),
-    ('composite_traintuple', 'composite_algo'),
-])
-@pytest.mark.parametrize('metadata', [
-    {'foo' * 40: "bar"},
-    {"foo": 'bar' * 40},
-])
-def test_traintuple_with_invalid_metadata(factory, client, asset_name, algo_type, default_dataset, metadata):
-    create_spec = getattr(factory, f"create_{asset_name}")
-    add_asset = getattr(client, f"add_{asset_name}")
-
-    algo_create = getattr(factory, f"create_{algo_type}")
-    algo_add = getattr(client, f"add_{algo_type}")
-
-    algo_spec = algo_create()
-    algo = algo_add(algo_spec)
-
-    spec = create_spec(
-        algo=algo,
-        dataset=default_dataset,
-        data_samples=default_dataset.train_data_sample_keys,
-        metadata=metadata
-    )
-
-    with pytest.raises(substra.exceptions.InvalidRequest):
-        add_asset(spec)
-
-
 def test_add_algo(factory, client):
     spec = factory.create_algo()
     algo = client.add_algo(spec)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -164,6 +164,7 @@ def test_add_objective(factory, client):
 def test_metadata(factory, client, asset_name):
     method_create = getattr(factory, f"create_{asset_name}")
     method_add = getattr(client, f"add_{asset_name}")
+    method_sdk_add = getattr(client._client, f"add_{asset_name}")
 
     # add an asset with metadata
     spec = method_create(metadata={"foo": "bar"})
@@ -183,13 +184,15 @@ def test_metadata(factory, client, asset_name):
 
     assert asset.metadata == {}
 
-    spec = method_create(metadata='foo')
-    asset = method_add(spec)
+    spec = method_create()
+    spec_dict = spec.dict()
+    spec_dict['metadata'] = 'foo'
 
-    assert asset.metadata == {}
+    with pytest.raises(substra.exceptions.InvalidRequest):
+        method_sdk_add(spec_dict)
 
     spec = method_create(metadata={'foo': {"bar": "foo"}})
-    with pytest.raises(ValueError):
+    with pytest.raises(substra.exceptions.InvalidRequest):
         method_add(spec)
 
     too_long = 'foo' * 40
@@ -257,7 +260,7 @@ def test_metadata_traintuple(factory, client, asset_name, algo_type, default_dat
         data_samples=default_dataset.train_data_sample_keys,
         metadata={'foo': {"bar": "foo"}}
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(substra.exceptions.InvalidRequest):
         method_add(spec)
 
     too_long = 'foo' * 40


### PR DESCRIPTION
🔗 **Related PRs:**
- [substra](https://github.com/SubstraFoundation/substra/pull/143)
- [substra-chaincode](https://github.com/SubstraFoundation/substra-chaincode/pull/111)
- [substra-backend](https://github.com/SubstraFoundation/substra-backend/pull/186)
- [substra-frontend (coming soon)](#)

The goal of these PRs is to add a `metadata` field in every asset in order to be able to store information related to this asset. It could be, for instance, a creation_ts, an epoch, a project_name, ...

Update 04/24:
> The following assets are missing in the tests:
> - dataset,
> - aggregatetuple (WIP),
> - compute_plan.

> The issue I currently have is that the metadata field returned by the aggregatetuple tests is set to an empty dict, but I pass:
{"foo": "bar"}
> I need to find a way to get the right output.

Update 06/03:
> The compute_plan asset cannot have a metadata field for now. It could be done later.