### PR TITLE
CI: Use 'eu' container registry

### DIFF
--- a/ci/cloudbuild/celerybeat.yaml
+++ b/ci/cloudbuild/celerybeat.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/substra-backend.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - --destination=gcr.io/$PROJECT_ID/celerybeat:${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/celerybeat:ci-${_COMMIT}
   - --cache=true
   - --dockerfile=substra-backend/docker/celerybeat/Dockerfile
   - --context=substra-backend

--- a/ci/cloudbuild/celeryworker.yaml
+++ b/ci/cloudbuild/celeryworker.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/substra-backend.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - --destination=gcr.io/$PROJECT_ID/celeryworker:${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/celeryworker:ci-${_COMMIT}
   - --cache=true
   - --dockerfile=substra-backend/docker/celeryworker/Dockerfile
   - --context=substra-backend

--- a/ci/cloudbuild/flower.yaml
+++ b/ci/cloudbuild/flower.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/substra-backend.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - --destination=gcr.io/$PROJECT_ID/flower:${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/flower:ci-${_COMMIT}
   - --cache=true
   - --dockerfile=substra-backend/docker/flower/Dockerfile
   - --context=substra-backend

--- a/ci/cloudbuild/hlf-k8s.yaml
+++ b/ci/cloudbuild/hlf-k8s.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/hlf-k8s.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - --destination=gcr.io/$PROJECT_ID/hlf-k8s:${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/hlf-k8s:ci-${_COMMIT}
   - --cache=true
   - --dockerfile=hlf-k8s/images/hlf-k8s/Dockerfile
   - --context=hlf-k8s

--- a/ci/cloudbuild/substra-backend.yaml
+++ b/ci/cloudbuild/substra-backend.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/substra-backend.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - --destination=gcr.io/$PROJECT_ID/substra-backend:${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/substra-backend:ci-${_COMMIT}
   - --cache=true
   - --dockerfile=substra-backend/docker/substra-backend/Dockerfile
   - --context=substra-backend

--- a/ci/cloudbuild/substra-tests.yaml
+++ b/ci/cloudbuild/substra-tests.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/substra-tests.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
-  - --destination=gcr.io/$PROJECT_ID/substra-tests:${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/substra-tests:ci-${_COMMIT}
   - --cache=true
   - --dockerfile=substra-tests/docker/substra-tests/Dockerfile
   - --context=substra-tests

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -376,7 +376,7 @@ def create_build_artifacts(config):
         for image in config['images']:
             tags['builds'].append({
                 'imageName': f'substrafoundation/{image}',
-                'tag': f'gcr.io/{CLUSTER_PROJECT}/{image}:{config["commit"]}'
+                'tag': f'eu.gcr.io/{CLUSTER_PROJECT}/{image}:ci-{config["commit"]}'
             })
 
         json.dump(tags, file)


### PR DESCRIPTION
- Store docker images in the same gcloud zone as the k8s cluster (`eu`)
  - This minimizes the $ cost of network transfers between the container registry and the kubernetes cluster (see [gcloud pricing](https://cloud.google.com/storage/pricing#network-egress))
- Add a `ci-` prefix to generated docker image tags. 
  - This makes it explicit that those images were created for the purpose of being run as part of CI script, and they can safely be deleted after the CI run has finished.
﻿
