### PR TITLE
remove statusCheckDeadlineSeconds patch

### DIFF
--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -392,12 +392,6 @@ def patch_skaffold_file(config):
     with open(skaffold_file, 'r') as file:
         filedata = file.read()
 
-    # Set statusCheckDeadlineSeconds to 300s instead of 120 default
-    filedata = filedata.replace(
-        'deploy:',
-        'deploy:\n  statusCheckDeadlineSeconds: 300'
-    )
-
     filedata = filedata.replace(
         'chartPath: charts/',
         f'chartPath: {os.path.join(SOURCE_DIR, config["name"],"charts/")}'


### PR DESCRIPTION
Companion PR: https://github.com/SubstraFoundation/hlf-k8s/pull/45

The skaffold patching is now unnecessary. Actually, we *need* to remove it because having `statusCheckDeadlineSeconds` twice in the `skaffold.yaml` file makes `skaffold deploy` crash 

```
FATA[0000] creating runner: parsing skaffold config: unable to parse YAML: yaml: unmarshal errors:
  line 30: key "statusCheckDeadlineSeconds" already set in map 
```
