### PR TITLE
CI: fix order of execution of helm init 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 branches:
   only:
     - master
+    - fix-helm-order
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 branches:
   only:
     - master
-    - fix-helm-order
 
 git:
   depth: 1

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -214,15 +214,11 @@ def wait_for_cluster():
 
 def setup_helm():
     print('\n# Setup Helm')
-    call(f'helm repo add bitnami https://charts.bitnami.com/bitnami')
-
-
-def setup_tiller():
-    print('\n# Setup Tiller')
     call(f'kubectl --context {KUBE_CONTEXT} create serviceaccount --namespace kube-system tiller')
     call(f'kubectl --context {KUBE_CONTEXT} create clusterrolebinding tiller-cluster-rule ' +
          f'--clusterrole=cluster-admin --serviceaccount=kube-system:tiller')
     call(f'helm --kube-context {KUBE_CONTEXT} init --service-account tiller --upgrade --wait')
+    call(f'helm repo add bitnami https://charts.bitnami.com/bitnami')
 
 
 def clone_repos():
@@ -447,7 +443,6 @@ def main():
         wait_for_cluster()
         get_kube_context()
         setup_helm()
-        setup_tiller()
         deploy_all(configs)
         is_success = run_tests()
         print("Completed test run:")


### PR DESCRIPTION
See end-to-end tests failure: ﻿https://travis-ci.org/github/SubstraFoundation/substra-tests/builds/696664654
