### PR TITLE
Tests on testtuple perf: replace equality test between float by isclose

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 
 import substra
@@ -36,7 +37,7 @@ def test_tuples_execution_on_same_node(factory, client, default_dataset, default
     spec = factory.create_testtuple(objective=default_objective, traintuple=traintuple)
     testtuple = client.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
-    assert testtuple.dataset.perf == 0.2
+    assert math.isclose(testtuple.dataset.perf, 0.2)
 
     # add a traintuple depending on first traintuple
     spec = factory.create_traintuple(
@@ -116,7 +117,7 @@ def test_tuples_execution_on_different_nodes(factory, client_1, client_2, defaul
     testtuple = client_1.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
     assert testtuple.dataset.worker == client_1.node_id
-    assert testtuple.dataset.perf == 0.2
+    assert math.isclose(testtuple.dataset.perf, 0.2)
 
 
 @pytest.mark.slow
@@ -223,7 +224,7 @@ def test_composite_traintuples_execution(factory, client, default_dataset, defau
     spec = factory.create_testtuple(objective=default_objective, traintuple=composite_traintuple_2)
     testtuple = client.add_testtuple(spec).future().wait()
     assert testtuple.status == assets.Status.done
-    assert testtuple.dataset.perf == 3.2
+    assert math.isclose(testtuple.dataset.perf, 3.2)
 
     # list composite traintuple
     composite_traintuples = client.list_composite_traintuple()
@@ -350,7 +351,7 @@ def test_aggregate_composite_traintuples(factory, network, clients, default_data
             traintuple=traintuple,
         )
         testtuple = clients[0].add_testtuple(spec).future().wait()
-        assert testtuple.dataset.perf == 3.2
+        math.isclose(testtuple.dataset.perf, 3.2)
 
     if not network.options.enable_intermediate_model_removal:
         return

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 import substra
 import substratest as sbt
@@ -91,7 +92,7 @@ def test_compute_plan(factory, client_1, client_2, default_dataset_1, default_da
     assert testtuple.rank == traintuple_3.rank
 
     # check testtuple perf
-    assert testtuple.dataset.perf == 0.4
+    assert math.isclose(testtuple.dataset.perf, 0.4)
 
     # XXX as the first two tuples have the same rank, there is currently no way to know
     #     which one will be returned first


### PR DESCRIPTION
## What this changes

In the tests, one common assertion is on the final performance of the testtuple:
`assert testtuple.dataset.perf == 0.2`

These tests fail at least with the local backend because of float precision:
`assert 0.20000000000000018 == 0.2`

The proposition is to replace all `assert testtuple.dataset.perf == x` with `assert math.isclose(testtuple.dataset.perf, x)`