### PR TITLE
DEPRECATED - Add tests on fake data - local backend

### DIFF
--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -29,6 +29,7 @@ class TestOpener(tools.Opener):
                 reader = csv.reader(f)
                 for row in reader:
                     res.append(int(row[0]))
+        print(f'get_X: {{res}}')
         return res  # returns a list of 1's
     def get_y(self, folders):
         res = []
@@ -37,11 +38,20 @@ class TestOpener(tools.Opener):
                 reader = csv.reader(f)
                 for row in reader:
                     res.append(int(row[1]))
+        print(f'get_y: {{res}}')
         return res  # returns a list of 2's
-    def fake_X(self, n_samples=1):
-        return [1] * n_samples
-    def fake_y(self, n_samples=1):
-        return [2] * n_samples
+    def fake_X(self, n_samples=None):
+        if n_samples is None:
+            n_samples = 1
+        res = [10] * n_samples
+        print(f'fake_X: {{res}}')
+        return res
+    def fake_y(self, n_samples=None):
+        if n_samples is None:
+            n_samples = 1
+        res = [30] * n_samples
+        print(f'fake_y: {{res}}')
+        return res
     def get_predictions(self, path):
         with open(path) as f:
             return json.load(f)
@@ -50,12 +60,14 @@ class TestOpener(tools.Opener):
             return json.dump(y_pred, f)
 """
 
-DEFAULT_METRICS_SCRIPT = """
+DEFAULT_METRICS_SCRIPT = f"""
 import json
 import substratools as tools
 class TestMetrics(tools.Metrics):
     def score(self, y_true, y_pred):
-        return sum(y_pred) - sum(y_true)
+        res = sum(y_pred) - sum(y_true)
+        print(f'metrics, y_true: {{y_true}}, y_pred: {{y_pred}}, result: {{res}}')
+        return res
 if __name__ == '__main__':
     tools.metrics.execute(TestMetrics())
 """
@@ -65,19 +77,25 @@ import json
 import substratools as tools
 class TestAlgo(tools.Algo):
     def train(self, X, y, models, rank):
+        print(f'Train, get X: {{X}}, y: {{y}}, models: {{models}}')
 
         ratio = sum(y) / sum(X)
         err = 0.1 * ratio  # Add a small error
 
         if len(models) == 0:
-            return {{'value': ratio + err }}
+            res = {{'value': ratio + err }}
         else:
             ratios = [m['value'] for m in models]
             avg = sum(ratios) / len(ratios)
-            return {{'value': avg + err }}
+            res = {{'value': avg + err }}
+
+        print(f'Train, return {{res}}')
+        return res
 
     def predict(self, X, model):
-        return [x * model['value'] for x in X]
+        res = [x * model['value'] for x in X]
+        print(f'Predict, get X: {{X}}, model: {{model}}, return {{res}}')
+        return res
 
     def load_model(self, path):
         with open(path) as f:
@@ -96,9 +114,12 @@ import json
 import substratools as tools
 class TestAggregateAlgo(tools.AggregateAlgo):
     def aggregate(self, models, rank):
+        print(f'Aggregate models: {{models}}')
         values = [m['value'] for m in models]
         avg = sum(values) / len(values)
-        return {{'value': avg}}
+        res = {{'value': avg}}
+        print(f'Aggregate result: {{res}}')
+        return res
     def load_model(self, path):
         with open(path) as f:
             return json.load(f)
@@ -117,6 +138,8 @@ import substratools as tools
 class TestCompositeAlgo(tools.CompositeAlgo):
     def train(self, X, y, head_model, trunk_model, rank):
 
+        print(f'Composite algo train X: {{X}}, y: {{y}}, head_model: {{head_model}}, trunk_model: {{trunk_model}}')
+
         ratio = sum(y) / sum(X)
         err_head = 0.1 * ratio  # Add a small error
         err_trunk = 0.2 * ratio  # Add a small error
@@ -130,11 +153,16 @@ class TestCompositeAlgo(tools.CompositeAlgo):
             res_trunk = trunk_model['value']
         else:
             res_trunk = ratio
-        return {{'value' : res_head + err_head }}, {{'value' : res_trunk + err_trunk }}
+
+        res = {{'value' : res_head + err_head }}, {{'value' : res_trunk + err_trunk }}
+        print(f'Composite algo train head, trunk result: {{res}}')
+        return res
 
     def predict(self, X, head_model, trunk_model):
+        print(f'Composite algo predict X: {{X}}, head_model: {{head_model}}, trunk_model: {{trunk_model}}')
         ratio_sum = head_model['value'] + trunk_model['value']
         res = [x * ratio_sum for x in X]
+        print(f'Composite algo predict result: {{res}}')
         return res
 
     def load_head_model(self, path):
@@ -286,6 +314,8 @@ class TraintupleSpec(_Spec):
     metadata: typing.Dict[str, str] = None
     compute_plan_id: str = None
     rank: int = None
+    fake_data: bool = False
+    n_fake_samples: typing.Optional[int] = None
 
 
 class AggregatetupleSpec(_Spec):
@@ -309,6 +339,8 @@ class CompositeTraintupleSpec(_Spec):
     compute_plan_id: str = None
     out_trunk_model_permissions: PrivatePermissions
     rank: int = None
+    fake_data: bool = False
+    n_fake_samples: typing.Optional[int] = None
 
 
 class TesttupleSpec(_Spec):
@@ -318,6 +350,8 @@ class TesttupleSpec(_Spec):
     data_manager_key: str = None
     test_data_sample_keys: typing.List[str] = None
     metadata: typing.Dict[str, str] = None
+    fake_data: bool = False
+    n_fake_samples: typing.Optional[int] = None
 
 
 class ComputePlanTraintupleSpec(_Spec):
@@ -328,6 +362,8 @@ class ComputePlanTraintupleSpec(_Spec):
     in_models_ids: typing.List[str] = None
     tag: str = None
     metadata: typing.Dict[str, str] = None
+    fake_data: bool = False
+    n_fake_samples: typing.Optional[int] = None
 
     @property
     def id(self):
@@ -357,6 +393,8 @@ class ComputePlanCompositeTraintupleSpec(_Spec):
     tag: str = None
     out_trunk_model_permissions: Permissions
     metadata: typing.Dict[str, str] = None
+    fake_data: bool = False
+    n_fake_samples: typing.Optional[int] = None
 
     @property
     def id(self):
@@ -368,6 +406,8 @@ class ComputePlanTesttupleSpec(_Spec):
     traintuple_id: str
     tag: str
     metadata: typing.Dict[str, str] = None
+    fake_data: bool = False
+    n_fake_samples: typing.Optional[int] = None
 
 
 def _get_key(obj, field='key'):
@@ -394,7 +434,8 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
     aggregatetuples: typing.List[ComputePlanAggregatetupleSpec]
     testtuples: typing.List[ComputePlanTesttupleSpec]
 
-    def add_traintuple(self, algo, dataset, data_samples, in_models=None, tag='', metadata=None):
+    def add_traintuple(self, algo, dataset, data_samples, in_models=None, tag='', metadata=None,
+                       fake_data=False, n_fake_samples=None, ):
         in_models = in_models or []
         spec = ComputePlanTraintupleSpec(
             algo_key=algo.key,
@@ -404,6 +445,8 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             in_models_ids=[t.id for t in in_models],
             tag=tag,
             metadata=metadata,
+            fake_data=fake_data,
+            n_fake_samples=n_fake_samples,
         )
         self.traintuples.append(spec)
         return spec
@@ -427,7 +470,8 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
 
     def add_composite_traintuple(self, composite_algo, dataset=None, data_samples=None,
                                  in_head_model=None, in_trunk_model=None,
-                                 out_trunk_model_permissions=None, tag='', metadata=None):
+                                 out_trunk_model_permissions=None, tag='', metadata=None,
+                                 fake_data=False, n_fake_samples=None,):
         data_samples = data_samples or []
 
         if in_head_model and in_trunk_model:
@@ -447,16 +491,28 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
             out_trunk_model_permissions=out_trunk_model_permissions or DEFAULT_OUT_TRUNK_MODEL_PERMISSIONS,
             tag=tag,
             metadata=metadata,
+            fake_data=fake_data,
+            n_fake_samples=n_fake_samples,
         )
         self.composite_traintuples.append(spec)
         return spec
 
-    def add_testtuple(self, objective, traintuple_spec, tag='', metadata=None):
+    def add_testtuple(
+        self,
+        objective,
+        traintuple_spec,
+        tag='',
+        metadata=None,
+        fake_data=False,
+        n_fake_samples=None,
+    ):
         spec = ComputePlanTesttupleSpec(
             objective_key=objective.key,
             traintuple_id=traintuple_spec.id,
             tag=tag,
             metadata=metadata,
+            fake_data=fake_data,
+            n_fake_samples=n_fake_samples
         )
         self.testtuples.append(spec)
         return spec
@@ -498,7 +554,7 @@ class AssetsFactory:
         if content:
             content = f'# random={rdm} \n'.encode(encoding) + content
         else:
-            # x=1, y=2. The last "random" column ensures the datasample is unique.
+            # x=10, y=20. The last "random" column ensures the datasample is unique.
             content = f'10,20,{rdm}\n'.encode(encoding)
 
         data_filepath = tmpdir / DEFAULT_DATA_SAMPLE_FILENAME
@@ -624,7 +680,8 @@ class AssetsFactory:
 
     def create_traintuple(self, algo=None, dataset=None,
                           data_samples=None, traintuples=None, tag=None,
-                          compute_plan_id=None, rank=None, metadata=None):
+                          compute_plan_id=None, rank=None, metadata=None,
+                          fake_data=False, n_fake_samples=None,):
         data_samples = data_samples or []
         traintuples = traintuples or []
 
@@ -640,6 +697,8 @@ class AssetsFactory:
             metadata=metadata,
             compute_plan_id=compute_plan_id,
             rank=rank,
+            fake_data=fake_data,
+            n_fake_samples=n_fake_samples,
         )
 
     def create_aggregatetuple(self, algo=None, worker=None,
@@ -664,7 +723,8 @@ class AssetsFactory:
                                     data_samples=None, head_traintuple=None,
                                     trunk_traintuple=None, tag=None,
                                     compute_plan_id=None, rank=None,
-                                    permissions=None, metadata=None):
+                                    permissions=None, metadata=None,
+                                    fake_data=False, n_fake_samples=None,):
         data_samples = data_samples or []
 
         if head_traintuple and trunk_traintuple:
@@ -690,10 +750,12 @@ class AssetsFactory:
             compute_plan_id=compute_plan_id,
             rank=rank,
             out_trunk_model_permissions=permissions or DEFAULT_OUT_TRUNK_MODEL_PERMISSIONS,
+            fake_data=fake_data,
+            n_fake_samples=n_fake_samples,
         )
 
     def create_testtuple(self, objective=None, traintuple=None, tag=None, dataset=None, data_samples=None,
-                         metadata=None):
+                         metadata=None, fake_data=False, n_fake_samples=None,):
         return TesttupleSpec(
             objective_key=objective.key if objective else None,
             traintuple_key=traintuple.key if traintuple else None,
@@ -701,6 +763,8 @@ class AssetsFactory:
             test_data_sample_keys=_get_keys(data_samples),
             tag=tag,
             metadata=metadata,
+            fake_data=fake_data,
+            n_fake_samples=n_fake_samples,
         )
 
     def create_compute_plan(self, tag='', clean_models=False, metadata=None):

--- a/tests/test_execution_fake_data.py
+++ b/tests/test_execution_fake_data.py
@@ -101,8 +101,8 @@ def test_composite_traintuple_fake_data(factory, client, default_dataset, defaul
     assert testtuple.dataset.perf == 48
 
 
-@pytest.mark.slow
 @pytest.mark.local_only
+@pytest.mark.slow
 def test_compute_plan_fake_data(factory, client, default_dataset, default_objective):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
@@ -123,7 +123,7 @@ def test_compute_plan_fake_data(factory, client, default_dataset, default_object
     traintuple_spec_1 = cp_spec.add_traintuple(
         algo=algo_2,
         dataset=default_dataset,
-        data_samples=default_dataset.train_data_sample_keys,
+        data_samples=list(),
         metadata=None,
         fake_data=True,
         n_fake_samples=1,
@@ -132,7 +132,7 @@ def test_compute_plan_fake_data(factory, client, default_dataset, default_object
     traintuple_spec_2 = cp_spec.add_traintuple(
         algo=algo_2,
         dataset=default_dataset,
-        data_samples=default_dataset.train_data_sample_keys,
+        data_samples=list(),
         in_models=[traintuple_spec_1],
         metadata={},
         fake_data=True,

--- a/tests/test_execution_fake_data.py
+++ b/tests/test_execution_fake_data.py
@@ -1,0 +1,150 @@
+import pytest
+
+import substra
+
+import substratest as sbt
+from substratest.factory import Permissions
+
+from substratest import assets
+
+
+@pytest.mark.local_only
+@pytest.mark.slow
+def test_traintuple_fake_data(factory, client, default_dataset, default_objective):
+    """Execution of a traintuple, a following testtuple and a following traintuple."""
+
+    spec = factory.create_algo()
+    algo = client.add_algo(spec)
+
+    # create traintuple
+    spec = factory.create_traintuple(
+        algo=algo,
+        dataset=default_dataset,
+        data_samples=list(),
+        metadata={"foo": "bar"},
+        fake_data=True,
+        n_fake_samples=1,
+    )
+    traintuple = client.add_traintuple(spec).future().wait()
+    print(traintuple.log.replace('\n', ''))
+
+    # create testtuple
+    # don't create it before to avoid MVCC errors
+    spec = factory.create_testtuple(objective=default_objective, traintuple=traintuple)
+    testtuple = client.add_testtuple(spec).future().wait()
+    print(testtuple.log)
+    assert testtuple.dataset.perf == 13
+
+    # add a traintuple depending on first traintuple
+    spec = factory.create_traintuple(
+        algo=algo,
+        dataset=default_dataset,
+        data_samples=list(),
+        traintuples=[traintuple],
+        metadata=None,
+        fake_data=True,
+        n_fake_samples=1,
+    )
+    traintuple = client.add_traintuple(spec).future().wait()
+    print(traintuple.log.replace('\n', ''))
+
+    # create testtuple
+    # don't create it before to avoid MVCC errors
+    spec = factory.create_testtuple(objective=default_objective, traintuple=traintuple)
+    testtuple = client.add_testtuple(spec).future().wait()
+    print(testtuple.log.replace('\n', ''))
+    assert testtuple.dataset.perf == 16
+
+
+@pytest.mark.local_only
+@pytest.mark.slow
+def test_composite_traintuple_fake_data(factory, client, default_dataset, default_objective):
+    """Execution of a traintuple, a following testtuple and a following traintuple."""
+
+    spec = factory.create_composite_algo()
+    algo = client.add_composite_algo(spec)
+
+    # first composite traintuple
+    spec = factory.create_composite_traintuple(
+        algo=algo,
+        dataset=default_dataset,
+        data_samples=list(),
+        fake_data=True,
+        n_fake_samples=1,
+    )
+    composite_traintuple_1 = client.add_composite_traintuple(spec).future().wait()
+    print(composite_traintuple_1.log.replace('\n', ''))
+
+    # second composite traintuple
+    spec = factory.create_composite_traintuple(
+        algo=algo,
+        dataset=default_dataset,
+        data_samples=list(),
+        head_traintuple=composite_traintuple_1,
+        trunk_traintuple=composite_traintuple_1,
+        fake_data=True,
+        n_fake_samples=1,
+    )
+    composite_traintuple_2 = client.add_composite_traintuple(spec).future().wait()
+    print(composite_traintuple_2.log.replace('\n', ''))
+
+    # add a 'composite' testtuple
+    spec = factory.create_testtuple(objective=default_objective, traintuple=composite_traintuple_2)
+    testtuple = client.add_testtuple(spec).future().wait()
+    print(testtuple.log.replace('\n', ''))
+    assert testtuple.dataset.perf == 58
+
+
+@pytest.mark.slow
+@pytest.mark.local_only
+def test_compute_plan(factory, client, default_dataset, default_objective):
+    """Execution of a compute plan containing multiple traintuples:
+    - 1 traintuple executed on node 1
+    - 1 traintuple executed on node 2
+    - 1 traintuple executed on node 1 depending on previous traintuples
+    - 1 testtuple executed on node 1 depending on the last traintuple
+    """
+
+    spec = factory.create_algo()
+    algo_2 = client.add_algo(spec)
+
+    # create compute plan
+    cp_spec = factory.create_compute_plan(
+        tag='foo',
+        metadata={"foo": "bar"},
+    )
+
+    traintuple_spec_1 = cp_spec.add_traintuple(
+        algo=algo_2,
+        dataset=default_dataset,
+        data_samples=default_dataset.train_data_sample_keys,
+        metadata=None,
+        fake_data=True,
+        n_fake_samples=1,
+    )
+
+    traintuple_spec_2 = cp_spec.add_traintuple(
+        algo=algo_2,
+        dataset=default_dataset,
+        data_samples=default_dataset.train_data_sample_keys,
+        in_models=[traintuple_spec_1],
+        metadata={},
+        fake_data=True,
+        n_fake_samples=1,
+    )
+
+    cp_spec.add_testtuple(
+        objective=default_objective,
+        traintuple_spec=traintuple_spec_2,
+        metadata={'foo': 'bar'},
+        fake_data=True,
+        n_fake_samples=1,
+    )
+
+    # submit compute plan and wait for it to complete
+    cp = client.add_compute_plan(cp_spec).future().wait()
+
+    # check testtuple perf
+    testtuples = cp.list_testtuple()
+    testtuple = testtuples[0]
+    assert testtuple.dataset.perf == 16

--- a/tests/test_execution_fake_data.py
+++ b/tests/test_execution_fake_data.py
@@ -1,12 +1,5 @@
 import pytest
 
-import substra
-
-import substratest as sbt
-from substratest.factory import Permissions
-
-from substratest import assets
-
 
 @pytest.mark.local_only
 @pytest.mark.slow
@@ -29,11 +22,15 @@ def test_traintuple_fake_data(factory, client, default_dataset, default_objectiv
     print(traintuple.log.replace('\n', ''))
 
     # create testtuple
-    # don't create it before to avoid MVCC errors
-    spec = factory.create_testtuple(objective=default_objective, traintuple=traintuple)
+    spec = factory.create_testtuple(
+        objective=default_objective,
+        traintuple=traintuple,
+        fake_data=True,
+        n_fake_samples=1,
+    )
     testtuple = client.add_testtuple(spec).future().wait()
     print(testtuple.log)
-    assert testtuple.dataset.perf == 13
+    assert testtuple.dataset.perf == 3
 
     # add a traintuple depending on first traintuple
     spec = factory.create_traintuple(
@@ -49,11 +46,15 @@ def test_traintuple_fake_data(factory, client, default_dataset, default_objectiv
     print(traintuple.log.replace('\n', ''))
 
     # create testtuple
-    # don't create it before to avoid MVCC errors
-    spec = factory.create_testtuple(objective=default_objective, traintuple=traintuple)
+    spec = factory.create_testtuple(
+        objective=default_objective,
+        traintuple=traintuple,
+        fake_data=True,
+        n_fake_samples=1,
+    )
     testtuple = client.add_testtuple(spec).future().wait()
     print(testtuple.log.replace('\n', ''))
-    assert testtuple.dataset.perf == 16
+    assert testtuple.dataset.perf == 6
 
 
 @pytest.mark.local_only
@@ -89,15 +90,20 @@ def test_composite_traintuple_fake_data(factory, client, default_dataset, defaul
     print(composite_traintuple_2.log.replace('\n', ''))
 
     # add a 'composite' testtuple
-    spec = factory.create_testtuple(objective=default_objective, traintuple=composite_traintuple_2)
+    spec = factory.create_testtuple(
+        objective=default_objective,
+        traintuple=composite_traintuple_2,
+        fake_data=True,
+        n_fake_samples=1,
+    )
     testtuple = client.add_testtuple(spec).future().wait()
     print(testtuple.log.replace('\n', ''))
-    assert testtuple.dataset.perf == 58
+    assert testtuple.dataset.perf == 48
 
 
 @pytest.mark.slow
 @pytest.mark.local_only
-def test_compute_plan(factory, client, default_dataset, default_objective):
+def test_compute_plan_fake_data(factory, client, default_dataset, default_objective):
     """Execution of a compute plan containing multiple traintuples:
     - 1 traintuple executed on node 1
     - 1 traintuple executed on node 2
@@ -147,4 +153,4 @@ def test_compute_plan(factory, client, default_dataset, default_objective):
     # check testtuple perf
     testtuples = cp.list_testtuple()
     testtuple = testtuples[0]
-    assert testtuple.dataset.perf == 16
+    assert testtuple.dataset.perf == 6


### PR DESCRIPTION
## **DEPRECATED**

This PR is no longer viable following the changes made to the "hybrid debugging" feature. It stays as a reference for now, will be deleted when the feature is integrated.

- Add tests on 'fake data' to test the local backend.  
- Make it easier to debug failures in performance assert: 
  - add print statements in the assets (these will be part of the execution logs in the local backend)
  - print the execution logs in the tests (not shown in case of success)