### PR TITLE
Separate CI for the tests on the remote and local backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ branches:
 git:
   depth: 1
 
+services:
+  - docker
+
 before_install:
   # Decrypt secrets
   # Secrets generated using the CLI: `travis encrypt-file --add [...]`
@@ -27,12 +30,17 @@ before_install:
   - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.7.0/skaffold-linux-amd64
   - chmod +x ./skaffold
   - mv ./skaffold $HOME/bin/
+  # Install substra and substra-tests (for the tests on the local backend)
+  - pip install --no-cache-dir "git+https://github.com/SubstraFoundation/substra.git@master"
+  - pip install --no-cache-dir -r requirements.txt
 
 script:
+  - make test-local
   - CLUSTER_NAME="substra-tests-$(date -u +'%Y-%m-%d-%Hh%M')"
   - cd ci/
   # Retry on failure. This is to account for the occasional hiccups in deployment of hlf-k8s/substra-backend (some pods occasionally fail to start, maybe 1 time out of 10-20).
   - travis_retry python -u ./run-ci.py --keys-directory=./keys/ --cluster-name=${CLUSTER_NAME}
+  # Tests on the local backend
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - chmod +x ./skaffold
   - mv ./skaffold $HOME/bin/
   # Install substra and substra-tests (for the tests on the local backend)
-  - pip install --no-cache-dir "${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
+  - pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
   - pip install --no-cache-dir -r requirements.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.7"
 
+# TODO uncomment before merging
 # branches:
 #  only:
 #    - master
@@ -9,43 +10,42 @@ python:
 git:
   depth: 1
 
-services:
-  - docker
-
-env:
-  global:
-    - SUBSTRA_GIT_REPO=https://github.com/SubstraFoundation/substra.git
-    - SUBSTRA_GIT_REF=master
-
-before_install:
-  # Decrypt secrets
-  # Secrets generated using the CLI: `travis encrypt-file --add [...]`
-  - openssl aes-256-cbc -K $encrypted_36785d287aa1_key -iv $encrypted_36785d287aa1_iv
-    -in ci/keys/substra-208412-3be0df12d87a.json.enc -out ci/keys/substra-208412-3be0df12d87a.json
-    -d
-  # Install helm (v2.16.7)
-  - curl https://get.helm.sh/helm-v2.16.7-linux-amd64.tar.gz -o helm-v2.16.7-linux-amd64.tar.gz
-  - tar xzf helm-v2.16.7-linux-amd64.tar.gz
-  - mv linux-amd64/helm linux-amd64/tiller $HOME/bin/
-  # Install kubectl
-  - curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
-  - chmod +x ./kubectl
-  - mv ./kubectl $HOME/bin/
-  # Install skaffold
-  - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.7.0/skaffold-linux-amd64
-  - chmod +x ./skaffold
-  - mv ./skaffold $HOME/bin/
-  # Install substra and substra-tests (for the tests on the local backend)
-  - pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
-  - pip install --no-cache-dir -r requirements.txt
-
-script:
-  - make test-local
-  - CLUSTER_NAME="substra-tests-$(date -u +'%Y-%m-%d-%Hh%M')"
-  - cd ci/
-  # Retry on failure. This is to account for the occasional hiccups in deployment of hlf-k8s/substra-backend (some pods occasionally fail to start, maybe 1 time out of 10-20).
-  - travis_retry python -u ./run-ci.py --keys-directory=./keys/ --cluster-name=${CLUSTER_NAME}
-  # Tests on the local backend
+jobs:
+  include:
+    - name: "Tests on the remote backend"
+      before_install:
+        # Decrypt secrets
+        # Secrets generated using the CLI: `travis encrypt-file --add [...]`
+        - openssl aes-256-cbc -K $encrypted_36785d287aa1_key -iv $encrypted_36785d287aa1_iv
+          -in ci/keys/substra-208412-3be0df12d87a.json.enc -out ci/keys/substra-208412-3be0df12d87a.json
+          -d
+        # Install helm (v2.16.7)
+        - curl https://get.helm.sh/helm-v2.16.7-linux-amd64.tar.gz -o helm-v2.16.7-linux-amd64.tar.gz
+        - tar xzf helm-v2.16.7-linux-amd64.tar.gz
+        - mv linux-amd64/helm linux-amd64/tiller $HOME/bin/
+        # Install kubectl
+        - curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+        - chmod +x ./kubectl
+        - mv ./kubectl $HOME/bin/
+        # Install skaffold
+        - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.7.0/skaffold-linux-amd64
+        - chmod +x ./skaffold
+        - mv ./skaffold $HOME/bin/
+      script:
+        - CLUSTER_NAME="substra-tests-$(date -u +'%Y-%m-%d-%Hh%M')"
+        - cd ci/
+        # Retry on failure. This is to account for the occasional hiccups in deployment of hlf-k8s/substra-backend (some pods occasionally fail to start, maybe 1 time out of 10-20).
+        - travis_retry python -u ./run-ci.py --keys-directory=./keys/ --cluster-name=${CLUSTER_NAME}
+    - name: "Tests on the local backend"
+      env:
+        - SUBSTRA_GIT_REPO=https://github.com/SubstraFoundation/substra.git
+        - SUBSTRA_GIT_REF=master
+      before_install:
+        # Install substra and substra-tests (for the tests on the local backend)
+        - pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
+        - pip install --no-cache-dir -r requirements.txt
+      script:
+        - make test-local
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,20 @@ language: python
 python:
   - "3.7"
 
-branches:
-  only:
-    - master
+# branches:
+#  only:
+#    - master
 
 git:
   depth: 1
 
 services:
   - docker
+
+env:
+  global:
+    - SUBSTRA_GIT_REPO=https://github.com/SubstraFoundation/substra.git
+    - SUBSTRA_GIT_REF=master
 
 before_install:
   # Decrypt secrets
@@ -31,7 +36,7 @@ before_install:
   - chmod +x ./skaffold
   - mv ./skaffold $HOME/bin/
   # Install substra and substra-tests (for the tests on the local backend)
-  - pip install --no-cache-dir "git+https://github.com/SubstraFoundation/substra.git@master"
+  - pip install --no-cache-dir "${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
   - pip install --no-cache-dir -r requirements.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,13 @@ language: python
 python:
   - "3.7"
 
-# TODO uncomment before merging
-# branches:
-#  only:
-#    - master
-
 git:
   depth: 1
 
 jobs:
   include:
     - name: "Tests on the remote backend"
+      if: branch = master OR type = cron
       before_install:
         # Decrypt secrets
         # Secrets generated using the CLI: `travis encrypt-file --add [...]`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
 jobs:
   include:
     - name: "Tests on the remote backend"
-      if: (branch = master AND NOT type = pull_request) OR type = cron
+      if: type = cron
       before_install:
         # Decrypt secrets
         # Secrets generated using the CLI: `travis encrypt-file --add [...]`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
 jobs:
   include:
     - name: "Tests on the remote backend"
-      if: branch = master OR type = cron
+      if: (branch = master AND NOT type = pull_request) OR type = cron
       before_install:
         # Decrypt secrets
         # Secrets generated using the CLI: `travis encrypt-file --add [...]`

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -425,10 +425,10 @@ def run_tests():
 
     try:
         # Run the tests on the remote and local backend
-        call(f'kubectl --context {KUBE_CONTEXT} exec {substra_tests_pod} -n substra-tests -- make test')
+        call(f'kubectl --context {KUBE_CONTEXT} exec {substra_tests_pod} -n substra-tests -- make test-remote')
         return True
     except subprocess.CalledProcessError:
-        print('FATAL: `make test` completed with a non-zero exit code. Did some test(s) fail?')
+        print('FATAL: `make test-remote` completed with a non-zero exit code. Did some test(s) fail?')
         return False
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -102,6 +102,7 @@ def test_link_dataset_with_datasamples(factory, client):
     assert dataset.train_data_sample_keys == [data_sample.key]
 
 
+@pytest.mark.remote_only
 @pytest.mark.skipif(not settings.HAS_SHARED_PATH, reason='requires a shared path')
 def test_add_data_sample_located_in_shared_path(factory, client, node_cfg):
     spec = factory.create_dataset()


### PR DESCRIPTION
Separate the CI on the remote and local backend:
- the tests on the remote are run with a deployed substra platform
- the tests on the local are run with only substra-tests and substra installed

Skip a test:
- skip the "shared paths" test on the local backend