### PR TITLE
Update with the hybrid debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,11 @@ jobs:
         - SUBSTRA_GIT_REF=master
       before_install:
         # Update Docker to the right version
-        - apt-get update
+        - sudo apt-get update
         - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
-        - apt-get update
-        - apt-get install docker-ce=5:19.03.12~3-0~ubuntu-xenial docker-ce-cli=5:19.03.12~3-0~ubuntu-xenial containerd.io=1.2.13-2
+        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
+        - sudo apt-get update
+        - sudo apt-get install docker-ce=5:19.03.12~3-0~ubuntu-xenial docker-ce-cli=5:19.03.12~3-0~ubuntu-xenial containerd.io=1.2.13-2
         - docker version
         # Install substra and substra-tests (for the tests on the local backend)
         - pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,19 @@ jobs:
         - SUBSTRA_GIT_REPO=https://github.com/SubstraFoundation/substra.git
         - SUBSTRA_GIT_REF=master
       before_install:
+        # Update Docker to the right version
+        - sudo apt-get update
+        - sudo apt-get install \
+            apt-transport-https \
+            ca-certificates \
+            curl \
+            gnupg-agent \
+            software-properties-common
+        - sudo add-apt-repository \
+            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) \
+            stable"
+        - sudo apt-get upgrade docker-ce=19.03
         # Install substra and substra-tests (for the tests on the local backend)
         - pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
         - pip install --no-cache-dir -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,12 @@ jobs:
       if: type = cron
       before_install:
         # Update Docker to the right version
-        # TODO
+        - sudo apt-get update
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
+        - sudo apt-get update
+        - sudo apt-get install docker-ce=5:19.03.12~3-0~ubuntu-xenial docker-ce-cli=5:19.03.12~3-0~ubuntu-xenial containerd.io=1.2.13-2
+        - docker version
         # Decrypt secrets
         # Secrets generated using the CLI: `travis encrypt-file --add [...]`
         - openssl aes-256-cbc -K $encrypted_36785d287aa1_key -iv $encrypted_36785d287aa1_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,7 @@ jobs:
       if: type = cron
       before_install:
         # Update Docker to the right version
-        - sudo apt-get update
-        - sudo apt-get install \
-            apt-transport-https \
-            ca-certificates \
-            curl \
-            gnupg-agent \
-            software-properties-common
-        - sudo add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) \
-            stable"
-        - sudo apt-get upgrade docker-ce=19.03
+        # TODO
         # Decrypt secrets
         # Secrets generated using the CLI: `travis encrypt-file --add [...]`
         - openssl aes-256-cbc -K $encrypted_36785d287aa1_key -iv $encrypted_36785d287aa1_iv
@@ -51,18 +40,12 @@ jobs:
         - SUBSTRA_GIT_REF=master
       before_install:
         # Update Docker to the right version
-        - sudo apt-get update
-        - sudo apt-get install \
-            apt-transport-https \
-            ca-certificates \
-            curl \
-            gnupg-agent \
-            software-properties-common
-        - sudo add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) \
-            stable"
-        - sudo apt-get upgrade docker-ce=19.03
+        - apt-get update
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
+        - apt-get update
+        - apt-get install docker-ce=5:19.03.12~3-0~ubuntu-xenial docker-ce-cli=5:19.03.12~3-0~ubuntu-xenial containerd.io=1.2.13-2
+        - docker version
         # Install substra and substra-tests (for the tests on the local backend)
         - pip install --no-cache-dir "git+${SUBSTRA_GIT_REPO}@${SUBSTRA_GIT_REF}"
         - pip install --no-cache-dir -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,19 @@ jobs:
     - name: "Tests on the remote backend"
       if: type = cron
       before_install:
+        # Update Docker to the right version
+        - sudo apt-get update
+        - sudo apt-get install \
+            apt-transport-https \
+            ca-certificates \
+            curl \
+            gnupg-agent \
+            software-properties-common
+        - sudo add-apt-repository \
+            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) \
+            stable"
+        - sudo apt-get upgrade docker-ce=19.03
         # Decrypt secrets
         # Secrets generated using the CLI: `travis encrypt-file --add [...]`
         - openssl aes-256-cbc -K $encrypted_36785d287aa1_key -iv $encrypted_36785d287aa1_iv

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -21,8 +21,8 @@ class Client:
         self.debug = debug
         self._client = substra.Client(debug=debug, url=address, version="0.0", insecure=False, token=token)
         if not token:
-            self._client.login(user, password)
-        self.token = self._client._token
+            token = self._client.login(user, password)
+        self.token = token
 
     def add_data_sample(self, spec, *args, **kwargs):
         res = self._client.add_data_sample(spec.dict(), *args, **kwargs)

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -14,13 +14,15 @@ class Client:
     Parses responses from server to return Asset instances.
     """
 
-    def __init__(self, debug, node_id=None, address=None, user=None, password=None):
+    def __init__(self, debug, node_id=None, address=None, token=None, user=None, password=None):
         super().__init__()
 
         self.node_id = node_id
         self.debug = debug
-        self._client = substra.Client(debug=debug, url=address, version="0.0", insecure=False)
-        self._client.login(user, password)
+        self._client = substra.Client(debug=debug, url=address, version="0.0", insecure=False, token=token)
+        if not token:
+            self._client.login(user, password)
+        self.token = self._client._token
 
     def add_data_sample(self, spec, *args, **kwargs):
         res = self._client.add_data_sample(spec.dict(), *args, **kwargs)

--- a/substratest/client.py
+++ b/substratest/client.py
@@ -14,12 +14,12 @@ class Client:
     Parses responses from server to return Asset instances.
     """
 
-    def __init__(self, backend, node_id=None, address=None, user=None, password=None):
+    def __init__(self, debug, node_id=None, address=None, user=None, password=None):
         super().__init__()
 
         self.node_id = node_id
-        self.backend = backend
-        self._client = substra.Client(backend=backend, url=address, version="0.0", insecure=False)
+        self.debug = debug
+        self._client = substra.Client(debug=debug, url=address, version="0.0", insecure=False)
         self._client.login(user, password)
 
     def add_data_sample(self, spec, *args, **kwargs):

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -29,6 +29,7 @@ class TestOpener(tools.Opener):
                 reader = csv.reader(f)
                 for row in reader:
                     res.append(int(row[0]))
+        print(f'get_X: {{res}}')
         return res  # returns a list of 1's
     def get_y(self, folders):
         res = []
@@ -37,11 +38,20 @@ class TestOpener(tools.Opener):
                 reader = csv.reader(f)
                 for row in reader:
                     res.append(int(row[1]))
+        print(f'get_y: {{res}}')
         return res  # returns a list of 2's
-    def fake_X(self, n_samples=1):
-        return [1] * n_samples
-    def fake_y(self, n_samples=1):
-        return [2] * n_samples
+    def fake_X(self, n_samples=None):
+        if n_samples is None:
+            n_samples = 1
+        res = [10] * n_samples
+        print(f'fake_X: {{res}}')
+        return res
+    def fake_y(self, n_samples=None):
+        if n_samples is None:
+            n_samples = 1
+        res = [30] * n_samples
+        print(f'fake_y: {{res}}')
+        return res
     def get_predictions(self, path):
         with open(path) as f:
             return json.load(f)
@@ -50,12 +60,14 @@ class TestOpener(tools.Opener):
             return json.dump(y_pred, f)
 """
 
-DEFAULT_METRICS_SCRIPT = """
+DEFAULT_METRICS_SCRIPT = f"""
 import json
 import substratools as tools
 class TestMetrics(tools.Metrics):
     def score(self, y_true, y_pred):
-        return sum(y_pred) - sum(y_true)
+        res = sum(y_pred) - sum(y_true)
+        print(f'metrics, y_true: {{y_true}}, y_pred: {{y_pred}}, result: {{res}}')
+        return res
 if __name__ == '__main__':
     tools.metrics.execute(TestMetrics())
 """
@@ -65,19 +77,25 @@ import json
 import substratools as tools
 class TestAlgo(tools.Algo):
     def train(self, X, y, models, rank):
+        print(f'Train, get X: {{X}}, y: {{y}}, models: {{models}}')
 
         ratio = sum(y) / sum(X)
         err = 0.1 * ratio  # Add a small error
 
         if len(models) == 0:
-            return {{'value': ratio + err }}
+            res = {{'value': ratio + err }}
         else:
             ratios = [m['value'] for m in models]
             avg = sum(ratios) / len(ratios)
-            return {{'value': avg + err }}
+            res = {{'value': avg + err }}
+
+        print(f'Train, return {{res}}')
+        return res
 
     def predict(self, X, model):
-        return [x * model['value'] for x in X]
+        res = [x * model['value'] for x in X]
+        print(f'Predict, get X: {{X}}, model: {{model}}, return {{res}}')
+        return res
 
     def load_model(self, path):
         with open(path) as f:
@@ -96,9 +114,12 @@ import json
 import substratools as tools
 class TestAggregateAlgo(tools.AggregateAlgo):
     def aggregate(self, models, rank):
+        print(f'Aggregate models: {{models}}')
         values = [m['value'] for m in models]
         avg = sum(values) / len(values)
-        return {{'value': avg}}
+        res = {{'value': avg}}
+        print(f'Aggregate result: {{res}}')
+        return res
     def load_model(self, path):
         with open(path) as f:
             return json.load(f)
@@ -117,6 +138,8 @@ import substratools as tools
 class TestCompositeAlgo(tools.CompositeAlgo):
     def train(self, X, y, head_model, trunk_model, rank):
 
+        print(f'Composite algo train X: {{X}}, y: {{y}}, head_model: {{head_model}}, trunk_model: {{trunk_model}}')
+
         ratio = sum(y) / sum(X)
         err_head = 0.1 * ratio  # Add a small error
         err_trunk = 0.2 * ratio  # Add a small error
@@ -130,11 +153,16 @@ class TestCompositeAlgo(tools.CompositeAlgo):
             res_trunk = trunk_model['value']
         else:
             res_trunk = ratio
-        return {{'value' : res_head + err_head }}, {{'value' : res_trunk + err_trunk }}
+
+        res = {{'value' : res_head + err_head }}, {{'value' : res_trunk + err_trunk }}
+        print(f'Composite algo train head, trunk result: {{res}}')
+        return res
 
     def predict(self, X, head_model, trunk_model):
+        print(f'Composite algo predict X: {{X}}, head_model: {{head_model}}, trunk_model: {{trunk_model}}')
         ratio_sum = head_model['value'] + trunk_model['value']
         res = [x * ratio_sum for x in X]
+        print(f'Composite algo predict result: {{res}}')
         return res
 
     def load_head_model(self, path):
@@ -451,7 +479,13 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
         self.composite_traintuples.append(spec)
         return spec
 
-    def add_testtuple(self, objective, traintuple_spec, tag='', metadata=None):
+    def add_testtuple(
+        self,
+        objective,
+        traintuple_spec,
+        tag='',
+        metadata=None,
+    ):
         spec = ComputePlanTesttupleSpec(
             objective_key=objective.key,
             traintuple_id=traintuple_spec.id,
@@ -498,7 +532,7 @@ class AssetsFactory:
         if content:
             content = f'# random={rdm} \n'.encode(encoding) + content
         else:
-            # x=1, y=2. The last "random" column ensures the datasample is unique.
+            # x=10, y=20. The last "random" column ensures the datasample is unique.
             content = f'10,20,{rdm}\n'.encode(encoding)
 
         data_filepath = tmpdir / DEFAULT_DATA_SAMPLE_FILENAME

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -13,6 +13,7 @@ from . import utils, assets
 
 
 DEFAULT_DATA_SAMPLE_FILENAME = 'data.csv'
+
 DEFAULT_SUBSTRATOOLS_VERSION = '0.6.1-minimal'
 
 DEFAULT_OPENER_SCRIPT = f"""

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -479,13 +479,7 @@ class _BaseComputePlanSpec(_Spec, abc.ABC):
         self.composite_traintuples.append(spec)
         return spec
 
-    def add_testtuple(
-        self,
-        objective,
-        traintuple_spec,
-        tag='',
-        metadata=None,
-    ):
+    def add_testtuple(self, objective, traintuple_spec, tag='', metadata=None):
         spec = ComputePlanTesttupleSpec(
             objective_key=objective.key,
             traintuple_id=traintuple_spec.id,

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -13,8 +13,7 @@ from . import utils, assets
 
 
 DEFAULT_DATA_SAMPLE_FILENAME = 'data.csv'
-
-DEFAULT_SUBSTRATOOLS_VERSION = '0.6.0-minimal'
+DEFAULT_SUBSTRATOOLS_VERSION = '0.6.1-minimal'
 
 DEFAULT_OPENER_SCRIPT = f"""
 import csv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,11 +62,11 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="session")
-def backend(request):
+def client_debug_local(request):
     local = request.config.getoption("--local")
     if local:
-        return "local"
-    return "remote"
+        return True
+    return False
 
 
 class _DataEnv:
@@ -112,7 +112,7 @@ def factory(request):
 
 
 @pytest.fixture(scope="session")
-def network(backend):
+def network(client_debug_local):
     """Network fixture.
 
     Network must ge started outside of the tests environment and the network is kept
@@ -122,13 +122,13 @@ def network(backend):
 
     Returns an instance of the `Network` class.
     """
-    if backend == "remote":
+    if not client_debug_local:
         cfg = settings.load()
     else:
         # TODO check what enable_intermediate_model_removal does
         cfg = settings.load_local_backend()
     clients = [sbt.Client(
-        debug=backend == "local",  # TODO better way
+        debug=client_debug_local,
         node_id=n.msp_id,
         address=n.address,
         user=n.user,
@@ -281,6 +281,7 @@ def clients(network):
 
 @pytest.fixture(scope="session")
 def debug_client(client):
+    """Client fixture in debug mode (first node)."""
     cfg = settings.load()
     node = cfg.nodes[0]
     return sbt.Client(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def factory(request):
 def network(backend):
     """Network fixture.
 
-    Network must started outside of the tests environment and the network is kept
+    Network must ge started outside of the tests environment and the network is kept
     alive while running all tests.
 
     Create network instance from settings.
@@ -267,7 +267,7 @@ def node_cfg():
     return cfg.nodes[0]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def client(network):
     """Client fixture (first node)."""
     return network.clients[0]
@@ -277,3 +277,18 @@ def client(network):
 def clients(network):
     """Client fixture (first node)."""
     return network.clients
+
+
+@pytest.fixture(scope="session")
+def debug_client(client):
+    # THIS DOES NOT WORK, AUTHORIZATION ERROR
+    cfg = settings.load()
+    node = cfg.nodes[0]
+    return sbt.Client(
+        debug=True,
+        node_id=node.msp_id,
+        address=node.address,
+        user=node.user,
+        password=node.password,
+        token=client.token
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ def network(backend):
         # TODO check what enable_intermediate_model_removal does
         cfg = settings.load_local_backend()
     clients = [sbt.Client(
-        backend=backend,
+        debug=backend == "local",  # TODO better way
         node_id=n.msp_id,
         address=n.address,
         user=n.user,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,6 +284,9 @@ def debug_client(client):
     """Client fixture in debug mode (first node)."""
     cfg = settings.load()
     node = cfg.nodes[0]
+    # Debug client and client share the same
+    # token, otherwise when one connects the other
+    # is disconnected.
     return sbt.Client(
         debug=True,
         node_id=node.msp_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,7 +281,6 @@ def clients(network):
 
 @pytest.fixture(scope="session")
 def debug_client(client):
-    # THIS DOES NOT WORK, AUTHORIZATION ERROR
     cfg = settings.load()
     node = cfg.nodes[0]
     return sbt.Client(

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -101,3 +101,8 @@ def test_debug_compute_plan_aggregate_composite(client, debug_client, factory, d
     tuples = traintuples + composite_traintuples + aggregatetuples + testtuples
     for t in tuples:
         assert t.status == assets.Status.done
+
+
+@pytest.mark.remote_only
+def test_debug_download_dataset(debug_client, default_dataset):
+    debug_client.download_opener(default_dataset.key)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,103 @@
+import pytest
+
+from substratest import assets
+from substratest.factory import Permissions
+
+
+@pytest.mark.remote_only
+@pytest.mark.slow
+def test_execution_debug(client, debug_client, factory, default_dataset, default_objective):
+
+    spec = factory.create_algo()
+    algo = client.add_algo(spec)
+
+    #  Add the traintuple
+    # create traintuple
+    spec = factory.create_traintuple(
+        algo=algo,
+        dataset=default_dataset,
+        data_samples=default_dataset.train_data_sample_keys[0],
+    )
+    traintuple = debug_client.add_traintuple(spec)
+    assert traintuple.status == assets.Status.done
+    assert traintuple.out_model is not None
+
+    # Add the testtuple
+    spec = factory.create_testtuple(
+        objective=default_objective,
+        traintuple=traintuple,
+        data_samples=default_dataset.test_data_sample_keys[0],
+    )
+    testtuple = debug_client.add_testtuple(spec).future().wait()
+    assert testtuple.status == assets.Status.done
+    assert testtuple.dataset.perf == 3
+
+
+@pytest.mark.remote_only
+@pytest.mark.slow
+def test_debug_compute_plan_aggregate_composite(client, debug_client, factory, default_datasets, default_objectives):
+    """
+    Debug / Compute plan version of the
+    `test_aggregate_composite_traintuples` method from `test_execution.py`
+    """
+    aggregate_worker = debug_client.node_id
+    number_of_rounds = 2
+
+    # register algos on first node
+    spec = factory.create_composite_algo()
+    composite_algo = client.add_composite_algo(spec)
+    spec = factory.create_aggregate_algo()
+    aggregate_algo = client.add_aggregate_algo(spec)
+
+    # launch execution
+    previous_aggregatetuple_spec = None
+    previous_composite_traintuple_specs = []
+
+    cp_spec = factory.create_compute_plan()
+
+    for round_ in range(number_of_rounds):
+        # create composite traintuple on each node
+        composite_traintuple_specs = []
+        for index, dataset in enumerate(default_datasets):
+            kwargs = {}
+            if previous_aggregatetuple_spec:
+                kwargs = {
+                    'in_head_model': previous_composite_traintuple_specs[index],
+                    'in_trunk_model': previous_aggregatetuple_spec,
+                }
+            spec = cp_spec.add_composite_traintuple(
+                composite_algo=composite_algo,
+                dataset=dataset,
+                data_samples=[dataset.train_data_sample_keys[0 + round_]],
+                out_trunk_model_permissions=Permissions(public=False, authorized_ids=[debug_client.node_id]),
+                **kwargs,
+            )
+            composite_traintuple_specs.append(spec)
+
+        # create aggregate on its node
+        spec = cp_spec.add_aggregatetuple(
+            aggregate_algo=aggregate_algo,
+            worker=aggregate_worker,
+            in_models=composite_traintuple_specs,
+        )
+
+        # save state of round
+        previous_aggregatetuple_spec = spec
+        previous_composite_traintuple_specs = composite_traintuple_specs
+
+    # last round: create associated testtuple
+    for composite_traintuple_spec, objective in zip(previous_composite_traintuple_specs, default_objectives):
+        cp_spec.add_testtuple(
+            objective=objective,
+            traintuple_spec=composite_traintuple_spec,
+        )
+
+    cp = debug_client.add_compute_plan(cp_spec).future().wait()
+    traintuples = cp.list_traintuple()
+    composite_traintuples = cp.list_composite_traintuple()
+    aggregatetuples = cp.list_aggregatetuple()
+    testtuples = cp.list_testtuple()
+
+    tuples = traintuples + composite_traintuples + aggregatetuples + testtuples
+    for t in tuples:
+        assert t.status == assets.Status.done

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -140,6 +140,7 @@ def test_traintuple_execution_failure(factory, client, default_dataset_1):
         assert traintuple.status == assets.Status.failed
         assert traintuple.out_model is None
 
+
 @pytest.mark.slow
 def test_composite_traintuple_execution_failure(factory, client, default_dataset):
     """Invalid composite algo script is causing traintuple failure."""

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -133,13 +133,12 @@ def test_traintuple_execution_failure(factory, client, default_dataset_1):
         data_samples=default_dataset_1.train_data_sample_keys,
     )
     if client.debug:
+        with pytest.raises(substra.sdk.backends.local.compute.spawner.ExecutionError):
+            traintuple = client.add_traintuple(spec)
+    else:
         traintuple = client.add_traintuple(spec).future().wait(raises=False)
         assert traintuple.status == assets.Status.failed
         assert traintuple.out_model is None
-    else:
-        with pytest.raises(substra.sdk.backends.local.compute.spawner.ExecutionError):
-            traintuple = client.add_traintuple(spec)
-
 
 @pytest.mark.slow
 def test_composite_traintuple_execution_failure(factory, client, default_dataset):
@@ -154,13 +153,13 @@ def test_composite_traintuple_execution_failure(factory, client, default_dataset
         data_samples=default_dataset.train_data_sample_keys,
     )
     if client.debug:
+        with pytest.raises(substra.sdk.backends.local.compute.spawner.ExecutionError):
+            composite_traintuple = client.add_composite_traintuple(spec)
+    else:
         composite_traintuple = client.add_composite_traintuple(spec).future().wait(raises=False)
         assert composite_traintuple.status == assets.Status.failed
         assert composite_traintuple.out_head_model.out_model is None
         assert composite_traintuple.out_trunk_model.out_model is None
-    else:
-        with pytest.raises(substra.sdk.backends.local.compute.spawner.ExecutionError):
-            composite_traintuple = client.add_composite_traintuple(spec)
 
 
 @pytest.mark.slow
@@ -188,15 +187,15 @@ def test_aggregatetuple_execution_failure(factory, client, default_dataset):
         worker=client.node_id,
     )
     if client.debug:
+        with pytest.raises(substra.sdk.backends.local.compute.spawner.ExecutionError):
+            aggregatetuple = client.add_aggregatetuple(spec)
+    else:
         aggregatetuple = client.add_aggregatetuple(spec).future().wait(raises=False)
         for composite_traintuple in composite_traintuples:
             composite_traintuple = client.get_composite_traintuple(composite_traintuple.key)
             assert composite_traintuple.status == assets.Status.done
         assert aggregatetuple.status == assets.Status.failed
         assert aggregatetuple.out_model is None
-    else:
-        with pytest.raises(substra.sdk.backends.local.compute.spawner.ExecutionError):
-            aggregatetuple = client.add_aggregatetuple(spec)
 
 
 @pytest.mark.slow
@@ -364,10 +363,10 @@ def test_aggregate_composite_traintuples(factory, network, clients, default_data
         )
         testtuple = clients[0].add_testtuple(spec).future().wait()
         if clients[0].debug:
-            assert testtuple.dataset.perf == 32
+            assert testtuple.dataset.perf == 30
         else:
             # There is only one dataset in 'datasets' in local, hence the difference
-            assert testtuple.dataset.perf == 30
+            assert testtuple.dataset.perf == 32
 
     if not network.options.enable_intermediate_model_removal:
         return

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -132,7 +132,7 @@ def test_traintuple_execution_failure(factory, client, default_dataset_1):
         dataset=default_dataset_1,
         data_samples=default_dataset_1.train_data_sample_keys,
     )
-    if client.backend == "remote":
+    if client.debug:
         traintuple = client.add_traintuple(spec).future().wait(raises=False)
         assert traintuple.status == assets.Status.failed
         assert traintuple.out_model is None
@@ -153,7 +153,7 @@ def test_composite_traintuple_execution_failure(factory, client, default_dataset
         dataset=default_dataset,
         data_samples=default_dataset.train_data_sample_keys,
     )
-    if client.backend == "remote":
+    if client.debug:
         composite_traintuple = client.add_composite_traintuple(spec).future().wait(raises=False)
         assert composite_traintuple.status == assets.Status.failed
         assert composite_traintuple.out_head_model.out_model is None
@@ -187,7 +187,7 @@ def test_aggregatetuple_execution_failure(factory, client, default_dataset):
         traintuples=composite_traintuples,
         worker=client.node_id,
     )
-    if client.backend == "remote":
+    if client.debug:
         aggregatetuple = client.add_aggregatetuple(spec).future().wait(raises=False)
         for composite_traintuple in composite_traintuples:
             composite_traintuple = client.get_composite_traintuple(composite_traintuple.key)
@@ -363,7 +363,7 @@ def test_aggregate_composite_traintuples(factory, network, clients, default_data
             traintuple=traintuple,
         )
         testtuple = clients[0].add_testtuple(spec).future().wait()
-        if clients[0].backend == 'remote':
+        if clients[0].debug:
             assert testtuple.dataset.perf == 32
         else:
             # There is only one dataset in 'datasets' in local, hence the difference


### PR DESCRIPTION
## Main changes

- Update substra-tests to add tests on the debug mode (following the changes in Substra: https://github.com/SubstraFoundation/substra/pull/206)
- Make it easier to debug failures in performance assert: 
  - add print statements in the assets (these will be part of the execution logs in the local backend)
  - print the execution logs in the tests (not shown in case of success)
- Fixed the CI: upgrade Docker to version 19
  - I fixed the versions of docker-ce, docker-ce-cli, containerd, **do we want to always use the latest stable version instead ?**

## Requirements

Need this PR to be merged: https://github.com/SubstraFoundation/substra-tools/pull/42 and to update the substra-tools image