### PR TITLE
CI: Don't retry run-ci.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ jobs:
       script:
         - CLUSTER_NAME="substra-tests-$(date -u +'%Y-%m-%d-%Hh%M')"
         - cd ci/
-        # Retry on failure. This is to account for the occasional hiccups in deployment of hlf-k8s/substra-backend (some pods occasionally fail to start, maybe 1 time out of 10-20).
-        - travis_retry python -u ./run-ci.py --keys-directory=./keys/ --cluster-name=${CLUSTER_NAME}
+        - python -u ./run-ci.py --keys-directory=./keys/ --cluster-name=${CLUSTER_NAME}
     - name: "Tests on the local backend"
       env:
         - SUBSTRA_GIT_REPO=https://github.com/SubstraFoundation/substra.git


### PR DESCRIPTION
We currently retry run-ci.py in case it fails the first time. This strategy was put in place because the deployment used to randomly fail (PVC not bound). 

However:
- we haven't seen this PVC issue in a while, so we can presume it's fixed
- the newest change to substra-backend (k8s tasks) significantly increase the run time of run-ci.py. The time limit for a Travis job is 50 min﻿, which is not enough time for two full runs of run-ci.py. As a result, if run-ci.py fails the first time then`run-ci.py` is retried, but we hit the 50 min mark and the build is marked as 'errored'.

This PR removes the retry so that if run-ci.py fails, the build is marked as failed without retrying.



