### PR TITLE
fix: expose docker socket to pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pyclean:
 test: test-remote test-local
 
 test-remote: pyclean
-	pytest tests/test_debug.py -rs -v --durations=0 -n $(PARALLELISM)
+	pytest tests -rs -v --durations=0 -n $(PARALLELISM)
 
 test-minimal: pyclean
 	pytest tests -rs -v --durations=0 -m "not slow" -n $(PARALLELISM)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pyclean:
 test: test-remote test-local
 
 test-remote: pyclean
-	pytest tests -rs -v --durations=0 -n $(PARALLELISM)
+	pytest tests/test_debug.py -rs -v --durations=0 -n $(PARALLELISM)
 
 test-minimal: pyclean
 	pytest tests -rs -v --durations=0 -m "not slow" -n $(PARALLELISM)

--- a/charts/substra-tests/templates/deployment.yaml
+++ b/charts/substra-tests/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
             - mountPath: /etc/substra/
               name: values
               readOnly: true
+            - mountPath: /var/run/docker.sock
+              name: docker-socket-volume
+          securityContext:
+            privileged: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -49,6 +53,10 @@ spec:
         - name: values
           configMap:
             name: {{ template "substra-tests.fullname" . }}-configmap
+        - name: docker-socket-volume
+          hostPath:
+            path: /var/run/docker.sock
+            type: File
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Chose to expose the docker socket to the pod.

Source: article on Medium https://medium.com/hootsuite-engineering/building-docker-images-inside-kubernetes-42c6af855f25

They recommend the 'Docker-in-Docker' solution, however when going to the official docker hub https://hub.docker.com/_/docker, they recommend this blog post: https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/ that basically recommends the 'exposing socket' solution so I went with it, as it does not seem so bad and is certainly simpler.

I cannot test the solution for the moment, need either to launch the job manually from the CI or get the credentials to run `ci/run_ci.py` locally.