### PR TITLE
fix: Docker in Docker solution to use Docker in the debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pyclean:
 test: test-remote test-local
 
 test-remote: pyclean
-	pytest tests/test_debug.py -rs -v --durations=0 -n $(PARALLELISM)
+	pytest tests -rs -v --durations=0 -n $(PARALLELISM)
 
 test-minimal: pyclean
 	pytest tests -rs -v --durations=0 -m "not slow" -n $(PARALLELISM)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pyclean:
 test: test-remote test-local
 
 test-remote: pyclean
-	pytest tests -rs -v --durations=0 -n $(PARALLELISM)
+	pytest tests/test_debug.py -rs -v --durations=0 -n $(PARALLELISM)
 
 test-minimal: pyclean
 	pytest tests -rs -v --durations=0 -m "not slow" -n $(PARALLELISM)

--- a/charts/substra-tests/templates/deployment.yaml
+++ b/charts/substra-tests/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
             - mountPath: /etc/substra/
               name: values
               readOnly: true
+            - mountPath: /var/run/docker.sock
+              name: docker-socket-volume
+          securityContext:
+            privileged: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -49,6 +53,10 @@ spec:
         - name: values
           configMap:
             name: {{ template "substra-tests.fullname" . }}-configmap
+        - name: docker-socket-volume
+          hostPath:
+            path: /var/run/docker.sock
+            type: File
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/substra-tests/templates/deployment.yaml
+++ b/charts/substra-tests/templates/deployment.yaml
@@ -37,26 +37,29 @@ spec:
           env:
             - name: SUBSTRA_TESTS_CONFIG_FILEPATH
               value: /etc/substra/values.yaml
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
           volumeMounts:
             - mountPath: /etc/substra/
               name: values
               readOnly: true
-            - mountPath: /var/run/docker.sock
-              name: docker-socket-volume
+        - name: dind
+          image: docker:stable-dind
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: dind-storage
+              mountPath: /var/lib/docker
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: dind-storage
+          emptyDir: {}
         - name: values
           configMap:
             name: {{ template "substra-tests.fullname" . }}-configmap
-        - name: docker-socket-volume
-          hostPath:
-            path: /var/run/docker.sock
-            type: File
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/substra-tests/templates/deployment.yaml
+++ b/charts/substra-tests/templates/deployment.yaml
@@ -39,23 +39,36 @@ spec:
               value: /etc/substra/values.yaml
             - name: DOCKER_HOST
               value: tcp://localhost:2376
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            - name: DOCKER_CERT_PATH
+              value: /root/.docker/client
           volumeMounts:
             - mountPath: /etc/substra/
               name: values
               readOnly: true
+            - name: dind-certs
+              mountPath: /root/.docker
         - name: dind
-          image: docker:stable-dind
+          image: docker:19.03.12-dind
           securityContext:
             privileged: true
           volumeMounts:
             - name: dind-storage
               mountPath: /var/lib/docker
+            - name: dind-certs
+              mountPath: /root/.docker
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: /root/.docker
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
         - name: dind-storage
+          emptyDir: {}
+        - name: dind-certs
           emptyDir: {}
         - name: values
           configMap:

--- a/charts/substra-tests/templates/deployment.yaml
+++ b/charts/substra-tests/templates/deployment.yaml
@@ -38,11 +38,13 @@ spec:
             - name: SUBSTRA_TESTS_CONFIG_FILEPATH
               value: /etc/substra/values.yaml
             - name: DOCKER_HOST
-              value: tcp://localhost:2375
+              value: tcp://localhost:2376
           volumeMounts:
             - mountPath: /etc/substra/
               name: values
               readOnly: true
+          securityContext:
+            privileged: true
         - name: dind
           image: docker:stable-dind
           securityContext:

--- a/charts/substra-tests/templates/deployment.yaml
+++ b/charts/substra-tests/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
             - mountPath: /etc/substra/
               name: values
               readOnly: true
-          securityContext:
-            privileged: true
         - name: dind
           image: docker:stable-dind
           securityContext:


### PR DESCRIPTION
Exposing the docker socket to the pod does not work because then we do not have permission to mount the volumes in RW on the Docker container

So this is the Docker in Docker method

## Old references

Source: article on Medium https://medium.com/hootsuite-engineering/building-docker-images-inside-kubernetes-42c6af855f25

They recommend the 'Docker-in-Docker' solution, however when going to the official docker hub https://hub.docker.com/_/docker, they recommend this blog post: https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/ that basically recommends the 'exposing socket' solution so I went with it, as it does not seem so bad and is certainly simpler.

I cannot test the solution for the moment, need either to launch the job manually from the CI or get the credentials to run ci/run_ci.py locally.