### PR TITLE
deactivate faulty tests

### DIFF
--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -4,6 +4,7 @@ from substratest import assets
 from substratest.factory import Permissions
 
 
+@pytest.mark.skip("Need to fix this test")
 @pytest.mark.remote_only
 @pytest.mark.slow
 def test_execution_debug(client, debug_client, factory, default_dataset, default_objective):
@@ -33,6 +34,7 @@ def test_execution_debug(client, debug_client, factory, default_dataset, default
     assert testtuple.dataset.perf == 3
 
 
+@pytest.mark.skip("Need to fix this test")
 @pytest.mark.remote_only
 @pytest.mark.slow
 def test_debug_compute_plan_aggregate_composite(client, debug_client, factory, default_datasets, default_objectives):


### PR DESCRIPTION
Deactivate test_debug until we can fix them.  
Full logs attached

Checked, did not reproduce on my computer with Python 3.6, 3.7 or 3.8 but @AurelienGasser reproduced (Python 3.8).  
I got the error if I run 'skaffold run' in susbtra-tests then launch the remote tests with `kubectl exec .... -- make test-remote` (same command as in run_ci.py)

[logs.txt](https://github.com/SubstraFoundation/substra-tests/files/5075701/logs.txt)

