### PR TITLE
Check that permissions are correctly set for composite traintuples in CP

### DIFF
--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -378,6 +378,9 @@ def test_compute_plan_aggregate_composite_traintuples(factory, clients, default_
     for tuple in composite_traintuples + aggregatetuples:
         assert tuple.metadata == {'foo': 'bar'}
 
+    # Check that permissions were correctly set
+    for tuple in composite_traintuples:
+        assert len(tuple.out_trunk_model.permissions.process.authorized_ids) == len(clients)
 
 @pytest.mark.slow
 @pytest.mark.remote_only


### PR DESCRIPTION
Note: this is currently failing against master.