### PR TITLE
Switch from Helm2 to Helm3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - chmod +x ./kubectl
         - mv ./kubectl $HOME/bin/
         # Install skaffold
-        - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.7.0/skaffold-linux-amd64
+        - curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.13.2/skaffold-linux-amd64
         - chmod +x ./skaffold
         - mv ./skaffold $HOME/bin/
         # Install pyyaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ jobs:
         - openssl aes-256-cbc -K $encrypted_36785d287aa1_key -iv $encrypted_36785d287aa1_iv
           -in ci/keys/substra-208412-3be0df12d87a.json.enc -out ci/keys/substra-208412-3be0df12d87a.json
           -d
-        # Install helm (v2.16.7)
-        - curl https://get.helm.sh/helm-v2.16.7-linux-amd64.tar.gz -o helm-v2.16.7-linux-amd64.tar.gz
-        - tar xzf helm-v2.16.7-linux-amd64.tar.gz
-        - mv linux-amd64/helm linux-amd64/tiller $HOME/bin/
+        # Install helm (v3.3.0)
+        - curl https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz -o helm-v3.3.0-linux-amd64.tar.gz
+        - tar xzf helm-v3.3.0-linux-amd64.tar.gz
+        - mv linux-amd64/helm $HOME/bin/
         # Install kubectl
         - curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
         - chmod +x ./kubectl

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -244,10 +244,6 @@ def wait_for_cluster():
 
 def setup_helm():
     print('\n# Setup Helm')
-    call(f'kubectl --context {KUBE_CONTEXT} create serviceaccount --namespace kube-system tiller')
-    call(f'kubectl --context {KUBE_CONTEXT} create clusterrolebinding tiller-cluster-rule ' +
-         '--clusterrole=cluster-admin --serviceaccount=kube-system:tiller')
-    call(f'helm --kube-context {KUBE_CONTEXT} init --service-account tiller --upgrade --wait')
     call('helm repo add bitnami https://charts.bitnami.com/bitnami')
 
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -33,4 +33,6 @@ deploy:
           helm: {}
         values:
           image: substrafoundation/substra-tests
+    flags:
+      install: ["--create-namespace"]
 


### PR DESCRIPTION
As we will only support Helm3 in the future the e2e test pipeline should use Helm3 to deploy the substra components in Kubernetes.

This PR should be merged only after these two PRs:
- https://github.com/SubstraFoundation/hlf-k8s/pull/82
- https://github.com/SubstraFoundation/substra-backend/pull/295