### PR TITLE
Use key instead of pkhash

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -132,7 +132,6 @@ class _ComputePlanFutureMixin(_BaseFutureMixin):
 _MANUAL_CONVERTION_FIELDS = {
     'authorizedIDs': 'authorized_ids',
     'dataManagerKey': 'dataset_key',
-    'pkhash': 'key',
 }
 
 
@@ -181,8 +180,6 @@ class Permissions(_InternalStruct):
 
 class DataSampleCreated(_Asset):
     key: str
-    validated: bool
-    path: str
 
 
 class DataSample(_Asset):


### PR DESCRIPTION
The goal of this multi-repo PRs is to make sure that all the asset creation endpoints returns only the "key" of the asset. 
Indeed, currently `create` and 'get' an asset return, respectively, `pkhash` and `key`. As `pkhash` is only a substra-backend concept, we need to move from `pkhash` to `key` when dealing with substra cli/sdk and frontend.

Consequently, when client create a new asset, the substra-backend will now only return the `key` of the created asset.

There is an exception for compute plan which need to be returned in its complete form because client need to get the ID_to_key mapping and it’s returned only when client create this asset.

The client will take care of doing an extra GET in order to retrieve the complete asset.

PRs :
    https://github.com/SubstraFoundation/substra-backend/pull/312
    https://github.com/SubstraFoundation/substra/pull/220
    https://github.com/SubstraFoundation/substra-tests/pull/140

