### PR TITLE
Switch from camel case to snake case

### DIFF
--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -129,22 +129,6 @@ class _ComputePlanFutureMixin(_BaseFutureMixin):
     _future_cls = ComputePlanFuture
 
 
-_MANUAL_CONVERTION_FIELDS = {
-    'data_manager_key': 'dataset_key',
-}
-
-
-def convert_asset_field_names(name):
-    """Converts asset camel case fields to snake case fields.
-
-    Special cases are handled through a global dict variable.
-    """
-    # XXX using a mapper for converting specific is not very flexible as it will be
-    #     applied to all fields from all assets.
-    mapper = _MANUAL_CONVERTION_FIELDS
-    return mapper[name] if name in mapper else name
-
-
 class _InternalStruct(pydantic.BaseModel, abc.ABC):
     """Internal nested structure."""
 
@@ -158,11 +142,8 @@ class _Asset(_InternalStruct, abc.ABC):
     @classmethod
     def load(cls, d):
         """Create asset from dictionary."""
-        # TODO we could use the pydantic alias generator feature to handle the case
-        # https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator
-        kwargs = utils.replace_dict_keys(d, convert_asset_field_names)
         try:
-            return cls(**kwargs)
+            return cls(**d)
         except TypeError as e:
             raise errors.TError(f"cannot parse asset `{d}`") from e
 
@@ -188,7 +169,7 @@ class DataSample(_Asset):
 
 
 class ObjectiveDataset(_InternalStruct):
-    dataset_key: str
+    data_manager_key: str
     data_sample_keys: typing.List[str]
 
 

--- a/substratest/assets.py
+++ b/substratest/assets.py
@@ -130,8 +130,7 @@ class _ComputePlanFutureMixin(_BaseFutureMixin):
 
 
 _MANUAL_CONVERTION_FIELDS = {
-    'authorizedIDs': 'authorized_ids',
-    'dataManagerKey': 'dataset_key',
+    'data_manager_key': 'dataset_key',
 }
 
 
@@ -143,7 +142,7 @@ def convert_asset_field_names(name):
     # XXX using a mapper for converting specific is not very flexible as it will be
     #     applied to all fields from all assets.
     mapper = _MANUAL_CONVERTION_FIELDS
-    return mapper[name] if name in mapper else utils.camel_to_snake(name)
+    return mapper[name] if name in mapper else name
 
 
 class _InternalStruct(pydantic.BaseModel, abc.ABC):
@@ -358,7 +357,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
 
     def list_traintuple(self):
         filters = [
-            f'traintuple:computePlanID:{self.compute_plan_id}',
+            f'traintuple:compute_plan_id:{self.compute_plan_id}',
         ]
         tuples = self._client.list_traintuple(filters=filters)
         assert len(tuples) == len(self.traintuple_keys)
@@ -368,7 +367,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
 
     def list_composite_traintuple(self):
         filters = [
-            f'composite_traintuple:computePlanID:{self.compute_plan_id}',
+            f'composite_traintuple:compute_plan_id:{self.compute_plan_id}',
         ]
         tuples = self._client.list_composite_traintuple(filters=filters)
         assert len(tuples) == len(self.composite_traintuple_keys)
@@ -378,7 +377,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
 
     def list_aggregatetuple(self):
         filters = [
-            f'aggregatetuple:computePlanID:{self.compute_plan_id}',
+            f'aggregatetuple:compute_plan_id:{self.compute_plan_id}',
         ]
         tuples = self._client.list_aggregatetuple(filters=filters)
         assert len(tuples) == len(self.aggregatetuple_keys)
@@ -388,7 +387,7 @@ class ComputePlan(_Asset, _ComputePlanFutureMixin):
 
     def list_testtuple(self):
         filters = [
-            f'testtuple:computePlanID:{self.compute_plan_id}',
+            f'testtuple:compute_plan_id:{self.compute_plan_id}',
         ]
         tuples = self._client.list_testtuple(filters=filters)
         assert len(tuples) == len(self.testtuple_keys)

--- a/substratest/utils.py
+++ b/substratest/utils.py
@@ -1,5 +1,4 @@
 import os
-import re
 import zipfile
 
 
@@ -22,12 +21,6 @@ def create_archive(tmpdir, *files):
         with open(tmpdir / path, 'w') as f:
             f.write(content)
     return zip_folder(str(tmpdir))
-
-
-def camel_to_snake(name):
-    """Convert camel case to snake case."""
-    s = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s).lower()
 
 
 def replace_dict_keys(d, converter):


### PR DESCRIPTION
The backend responses should be more consistent. The goal of this PR is to make sure that all inputs fields and response fields of backend endpoints are in snake_case format.

PRs:
https://github.com/SubstraFoundation/substra-backend/pull/315
https://github.com/SubstraFoundation/substra/pull/222
https://github.com/SubstraFoundation/substra-tests/pull/142
