### PR TITLE
Simplify celery images

### DIFF
--- a/ci/cloudbuild/celery.yaml
+++ b/ci/cloudbuild/celery.yaml
@@ -3,9 +3,9 @@ steps:
   args: ['clone', 'https://github.com/SubstraFoundation/substra-backend.git', '--depth', '1', '--branch', '${_BRANCH}']
 - name: 'gcr.io/kaniko-project/executor:v1.0.0'
   args:
-  - --destination=eu.gcr.io/$PROJECT_ID/celerybeat:ci-${_COMMIT}
+  - --destination=eu.gcr.io/$PROJECT_ID/celery:ci-${_COMMIT}
   - --cache=true
-  - --dockerfile=substra-backend/docker/celerybeat/Dockerfile
+  - --dockerfile=substra-backend/docker/celery/Dockerfile
   - --context=substra-backend
   - --cache-ttl=${_KANIKO_CACHE_TTL}
 tags:

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -59,7 +59,7 @@ KEY_SERVICE_ACCOUNT = 'substra-208412-3be0df12d87a.json'
 
 SUBSTRA_TESTS_BRANCH = 'master'
 SUBSTRA_BRANCH = 'master'
-SUBSTRA_BACKEND_BRANCH = 'master'
+SUBSTRA_BACKEND_BRANCH = 'simplify-celery-images'
 HLF_K8S_BRANCH = 'master'
 
 DIR = os.path.dirname(os.path.realpath(__file__))
@@ -276,14 +276,14 @@ def clone_repos():
          'commit': commit_hlf,
          'branch': HLF_K8S_BRANCH},
         {'name': 'substra-backend',
-         'images': ['substra-backend', 'celeryworker', 'celerybeat', 'flower'],
+         'images': ['substra-backend', 'celery', 'flower'],
          'commit': commit_backend,
          'branch': SUBSTRA_BACKEND_BRANCH},
         {'name': 'substra-tests',
          'images': ['substra-tests'],
          'commit': commit_substra_tests,
          'branch': SUBSTRA_TESTS_BRANCH,
-         'substra_commit' : commit_substra}
+         'substra_commit': commit_substra}
     ]
 
 

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -59,7 +59,7 @@ KEY_SERVICE_ACCOUNT = 'substra-208412-3be0df12d87a.json'
 
 SUBSTRA_TESTS_BRANCH = 'master'
 SUBSTRA_BRANCH = 'master'
-SUBSTRA_BACKEND_BRANCH = 'simplify-celery-images'
+SUBSTRA_BACKEND_BRANCH = 'master'
 HLF_K8S_BRANCH = 'master'
 
 DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
As https://github.com/SubstraFoundation/substra-backend/pull/320 has been merged, we can simplify celery services images to only one.
You can launch the ci with `./ci/run-ci.py --substra-backend simplify-celery-images`
Companion PR
https://github.com/SubstraFoundation/substra-backend/pull/323