### PR TITLE
Use random UUIDs for asset keys (instead of content hashes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ venv.bak/
 # IDE
 .idea
 .vscode
+
+local-worker/

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -539,7 +539,7 @@ class AssetsFactory:
         tmpdir = self._workdir / f'data-{idx}'
         tmpdir.mkdir()
 
-        content = (content or '10,20')
+        content = content or '10,20'
         content = content.encode('utf-8')
 
         data_filepath = tmpdir / DEFAULT_DATA_SAMPLE_FILENAME

--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -535,17 +535,12 @@ class AssetsFactory:
         shutil.rmtree(str(self._workdir), ignore_errors=True)
 
     def create_data_sample(self, content=None, datasets=None, test_only=False):
-        rdm = random.random()
         idx = self._data_sample_counter.inc()
         tmpdir = self._workdir / f'data-{idx}'
         tmpdir.mkdir()
 
-        encoding = 'utf-8'
-        if content:
-            content = f'# random={rdm} \n'.encode(encoding) + content
-        else:
-            # x=10, y=20. The last "random" column ensures the datasample is unique.
-            content = f'10,20,{rdm}\n'.encode(encoding)
+        content = (content or '10,20')
+        content = content.encode('utf-8')
 
         data_filepath = tmpdir / DEFAULT_DATA_SAMPLE_FILENAME
         with open(data_filepath, 'wb') as f:
@@ -560,7 +555,6 @@ class AssetsFactory:
         )
 
     def create_dataset(self, objective=None, permissions=None, metadata=None):
-        rdm = random.random()
         idx = self._dataset_counter.inc()
         tmpdir = self._workdir / f'dataset-{idx}'
         tmpdir.mkdir()
@@ -572,9 +566,8 @@ class AssetsFactory:
             f.write(description_content)
 
         opener_path = tmpdir / 'opener.py'
-        opener_content = f'# random={rdm} \n' + DEFAULT_OPENER_SCRIPT
         with open(opener_path, 'w') as f:
-            f.write(opener_content)
+            f.write(DEFAULT_OPENER_SCRIPT)
 
         return DatasetSpec(
             name=name,
@@ -587,22 +580,19 @@ class AssetsFactory:
         )
 
     def create_objective(self, dataset=None, data_samples=None, permissions=None, metadata=None):
-        rdm = random.random()
         idx = self._objective_counter.inc()
         tmpdir = self._workdir / f'objective-{idx}'
         tmpdir.mkdir()
         name = _shorten_name(f'{self._uuid} - Objective {idx}')
 
         description_path = tmpdir / 'description.md'
-        description_content = f'# random={rdm} {name}'
+        description_content = name
         with open(description_path, 'w') as f:
             f.write(description_content)
 
-        metrics_content = f'# random={rdm} \n' + DEFAULT_METRICS_SCRIPT
-
         metrics_zip = utils.create_archive(
             tmpdir / 'metrics',
-            ('metrics.py', metrics_content),
+            ('metrics.py', DEFAULT_METRICS_SCRIPT),
             ('Dockerfile', DEFAULT_METRICS_DOCKERFILE),
         )
 
@@ -620,7 +610,6 @@ class AssetsFactory:
         )
 
     def _create_algo(self, py_script, permissions=None, metadata=None):
-        rdm = random.random()
         idx = self._algo_counter.inc()
         tmpdir = self._workdir / f'algo-{idx}'
         tmpdir.mkdir()
@@ -631,7 +620,7 @@ class AssetsFactory:
         with open(description_path, 'w') as f:
             f.write(description_content)
 
-        algo_content = f'# random={rdm} \n' + py_script
+        algo_content = py_script
 
         algo_zip = utils.create_archive(
             tmpdir / 'algo',

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -29,9 +29,8 @@ def test_tuples_execution_on_same_node(factory, client, default_dataset, default
     assert traintuple.metadata == {"foo": "bar"}
     assert traintuple.out_model is not None
 
-    # check we cannot add twice the same traintuple
-    with pytest.raises(substra.exceptions.AlreadyExists):
-        client.add_traintuple(spec)
+    # check we can add twice the same traintuple
+    client.add_traintuple(spec)
 
     # create testtuple
     # don't create it before to avoid MVCC errors

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -46,9 +46,6 @@ def test_add_duplicate_dataset(factory, client):
     # does not raise
     client.add_dataset(spec)
 
-    dataset_copy = client.add_dataset(spec, exist_ok=True)
-    assert dataset == dataset_copy
-
 
 def test_link_dataset_with_objective(factory, client):
     spec = factory.create_objective()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -256,7 +256,4 @@ def test_error_get_asset_invalid_request(asset_type, client):
 def test_error_get_asset_not_found(asset_type, client):
     method = getattr(client, f'get_{asset_type.name}')
     with pytest.raises(substra.exceptions.NotFound):
-        if str(asset_type) in ['AssetType.objective', 'AssetType.dataset']:
-            method(str(uuid.uuid4()))
-        else:
-            method('42' * 32)  # a valid key must have a 64 length
+        method(str(uuid.uuid4()))

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -39,12 +39,12 @@ def test_describe_dataset(factory, client):
     assert content == spec.read_description()
 
 
-def test_add_dataset_conflict(factory, client):
+def test_add_duplicate_dataset(factory, client):
     spec = factory.create_dataset()
     dataset = client.add_dataset(spec)
 
-    with pytest.raises(substra.exceptions.AlreadyExists):
-        client.add_dataset(spec)
+    # does not raise
+    client.add_dataset(spec)
 
     dataset_copy = client.add_dataset(spec, exist_ok=True)
     assert dataset == dataset_copy

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,5 +1,5 @@
 import os
-
+import uuid
 import substra
 
 import pytest
@@ -259,4 +259,7 @@ def test_error_get_asset_invalid_request(asset_type, client):
 def test_error_get_asset_not_found(asset_type, client):
     method = getattr(client, f'get_{asset_type.name}')
     with pytest.raises(substra.exceptions.NotFound):
-        method('42' * 32)  # a valid key must have a 64 length
+        if str(asset_type) in ['AssetType.objective', 'AssetType.dataset']:
+            method(str(uuid.uuid4()))
+        else:
+            method('42' * 32)  # a valid key must have a 64 length


### PR DESCRIPTION
Companion PRs:

- https://github.com/SubstraFoundation/substra/pull/235
- https://github.com/SubstraFoundation/substra-backend/pull/342
- https://github.com/SubstraFoundation/substra-chaincode/pull/128

**Please see the main PR in substra-backend for a detailed description of the changes:** https://github.com/SubstraFoundation/substra-backend/pull/342

---

The mechanism adding random variations to assets specs is now obsolete (because unnecessary) and has been removed.