### PR TITLE
Add missing stable helm repo to run the remote CI

### DIFF
--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -288,6 +288,7 @@ def wait_for_cluster():
 
 def setup_helm():
     print('\n# Setup Helm')
+    call('helm repo add stable https://charts.helm.sh/stable')
     call('helm repo add owkin https://owkin.github.io/charts/')
     call('helm repo add bitnami https://charts.bitnami.com/bitnami')
 


### PR DESCRIPTION
## Description

The substra-tests nightly CI, executing nightly tests triggered by a cron, is failing. From the travis logs, it looks like helm stable repo is missing. Nevertheless, when running the `ci/run-ci.py` manually, we don't see this error.

## Closes issue(s)

None

## How to test / repro

We cannot repro this by running `ci/run-ci.py` which will, strangely, work without any issue :(

## Screenshots / Trace
Trace of the error can be found here : https://travis-ci.org/github/SubstraFoundation/substra-tests/jobs/744318430#L377-L379

![image](https://user-images.githubusercontent.com/7353847/99502743-d0765980-297d-11eb-9339-dd81d77a8f7c.png)


## Changes include
- [x] Add helm stable repo : https://charts.helm.sh/stable


## Checklist
- [x] I have tested this code with `ci/run-ci.py` but we need to wait the travis cron job to be executed as soon as this PR is merged.

## Other comments

To confirm the fix of this issue we need to merge this PR before and wait for the next travis cron job
