### PR TITLE
Add zones filtering for gcloud disks list and delete

### DIFF
--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -250,12 +250,12 @@ def delete_cluster():
 
 def delete_disks():
     try:
-        filter = f'name~^gke-{PVC_VOLUME_NAME_PREFIX}-pvc-.* AND -users:*'
+        filter = f'name~^gke-{PVC_VOLUME_NAME_PREFIX}-pvc-.* AND -users:* AND -zones:({CLUSTER_ZONE})'
         cmd = f'gcloud compute disks list --format="table(name)" --filter="{filter}" | sed 1d'
         disks = call_output(cmd)
         disks = disks.replace("\n", " ")
         if disks:
-            call(f'gcloud compute disks delete --quiet {disks}')
+            call(f'gcloud compute disks delete --zone {CLUSTER_ZONE} --quiet {disks}')
     except Exception as ex:
         print('ERROR: Deletion of the GCP disks failed', ex)
 


### PR DESCRIPTION
## Description
It looks like `gcloud` cli response on `compute disks delete` put the light on the need to use `--zone` option to be able to delete disks. I added in the PR the option for `compute disks list` and `compute disks delete` 

## Closes issue(s)
None
## Companion PRs
None

## How to test / repro

You can repro it by launching `ci/run-ci.py` on master branch.

## Screenshots / Trace
```shell
+ gcloud compute disks list --format="table(name)" --filter="name~^gke-substra-tests-slyk-pvc-.* AND -users:*" | sed 1d
+ gcloud compute disks delete --quiet gke-substra-tests-slyk-pvc-0423b7bf-74ba-4e98-be89-1ea531a9149f gke-substra-tests-slyk-pvc-07c72a4c-5bb3-4bc3-990d-8e6980e0e906 gke-substra-tests-slyk-pvc-10c0c9e9-5dbb-4268-8089-bb4442ed4cf4 gke-subs
tra-tests-slyk-pvc-18b2097b-a7f0-42ad-8f22-143f246ce91e gke-substra-tests-slyk-pvc-1bc0d4fb-a0c8-49b3-a468-5d3dbc974f49 gke-substra-tests-slyk-pvc-209423fa-544e-4184-84cf-7860256a9aa8 gke-substra-tests-slyk-pvc-273af266-fd71-483c-b8d8-bc3
ebbe6f5c6 gke-substra-tests-slyk-pvc-2db48f07-e8cd-48a9-9d9f-01970b666115 gke-substra-tests-slyk-pvc-3018a0e0-641e-4f71-b079-5de8467eb637 gke-substra-tests-slyk-pvc-3cae3757-b386-4dae-a982-73d02e9e7ef0 gke-substra-tests-slyk-pvc-43c185f6-
de2b-4829-a0d9-e98dd6a245db gke-substra-tests-slyk-pvc-5d00939f-3bed-45bb-82d9-793031ac15e9 gke-substra-tests-slyk-pvc-5f9e78a6-2c72-4df9-9e8c-3ea394450967 gke-substra-tests-slyk-pvc-6d5a76ff-bbee-418e-8e24-7515597422e3 gke-substra-tests-
slyk-pvc-7802f2e8-9b9a-412a-9533-b1514766acfe gke-substra-tests-slyk-pvc-8c88102f-ceb2-4825-9e5b-e1c8058e0418 gke-substra-tests-slyk-pvc-97997789-ee1b-419d-a66d-040b46d2ec5d gke-substra-tests-slyk-pvc-aea0f730-28b5-498d-8a58-651131ba3504
gke-substra-tests-slyk-pvc-bc30a525-bb15-421b-90c0-6f15328cbc60 gke-substra-tests-slyk-pvc-c0ce633e-bef2-4522-80e6-5c37d957ad85 gke-substra-tests-slyk-pvc-c224d8d3-c311-4bde-9f3a-95b3fe5eb0a4 gke-substra-tests-slyk-pvc-cea49df7-100c-4d7d-
bcb9-488f90b8a01b gke-substra-tests-slyk-pvc-dd908d0d-767a-4392-91f2-06a759a40c76 gke-substra-tests-slyk-pvc-df3e2b4c-923a-4cb3-87c6-3382fa1a9730 gke-substra-tests-slyk-pvc-e2d7ba5e-b131-4507-b551-041ac09a7a79 gke-substra-tests-slyk-pvc-e
755813b-7d85-415e-83ec-0a3d73d47b2e
ERROR: (gcloud.compute.disks.delete) Could not fetch resource:
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-0423b7bf-74ba-4e98-be89-1ea531a9149f' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-07c72a4c-5bb3-4bc3-990d-8e6980e0e906' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-10c0c9e9-5dbb-4268-8089-bb4442ed4cf4' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-18b2097b-a7f0-42ad-8f22-143f246ce91e' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-1bc0d4fb-a0c8-49b3-a468-5d3dbc974f49' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-209423fa-544e-4184-84cf-7860256a9aa8' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-273af266-fd71-483c-b8d8-bc3ebbe6f5c6' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-2db48f07-e8cd-48a9-9d9f-01970b666115' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-3018a0e0-641e-4f71-b079-5de8467eb637' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-3cae3757-b386-4dae-a982-73d02e9e7ef0' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-43c185f6-de2b-4829-a0d9-e98dd6a245db' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-5d00939f-3bed-45bb-82d9-793031ac15e9' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-5f9e78a6-2c72-4df9-9e8c-3ea394450967' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-6d5a76ff-bbee-418e-8e24-7515597422e3' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-7802f2e8-9b9a-412a-9533-b1514766acfe' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-8c88102f-ceb2-4825-9e5b-e1c8058e0418' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-97997789-ee1b-419d-a66d-040b46d2ec5d' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-aea0f730-28b5-498d-8a58-651131ba3504' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-bc30a525-bb15-421b-90c0-6f15328cbc60' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-c0ce633e-bef2-4522-80e6-5c37d957ad85' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-c224d8d3-c311-4bde-9f3a-95b3fe5eb0a4' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-cea49df7-100c-4d7d-bcb9-488f90b8a01b' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-dd908d0d-767a-4392-91f2-06a759a40c76' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-df3e2b4c-923a-4cb3-87c6-3382fa1a9730' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-e2d7ba5e-b131-4507-b551-041ac09a7a79' was not found
 - The resource 'projects/substra-208412/zones/europe-west1-b/disks/gke-substra-tests-slyk-pvc-e755813b-7d85-415e-83ec-0a3d73d47b2e' was not found

ERROR: Deletion of the GCP disks failed Command '['gcloud compute disks delete --quiet gke-substra-tests-slyk-pvc-0423b7bf-74ba-4e98-be89-1ea531a9149f gke-substra-tests-slyk-pvc-07c72a4c-5bb3-4bc3-990d-8e6980e0e906 gke-substra-tests-slyk-
pvc-10c0c9e9-5dbb-4268-8089-bb4442ed4cf4 gke-substra-tests-slyk-pvc-18b2097b-a7f0-42ad-8f22-143f246ce91e gke-substra-tests-slyk-pvc-1bc0d4fb-a0c8-49b3-a468-5d3dbc974f49 gke-substra-tests-slyk-pvc-209423fa-544e-4184-84cf-7860256a9aa8 gke-s
ubstra-tests-slyk-pvc-273af266-fd71-483c-b8d8-bc3ebbe6f5c6 gke-substra-tests-slyk-pvc-2db48f07-e8cd-48a9-9d9f-01970b666115 gke-substra-tests-slyk-pvc-3018a0e0-641e-4f71-b079-5de8467eb637 gke-substra-tests-slyk-pvc-3cae3757-b386-4dae-a982-
73d02e9e7ef0 gke-substra-tests-slyk-pvc-43c185f6-de2b-4829-a0d9-e98dd6a245db gke-substra-tests-slyk-pvc-5d00939f-3bed-45bb-82d9-793031ac15e9 gke-substra-tests-slyk-pvc-5f9e78a6-2c72-4df9-9e8c-3ea394450967 gke-substra-tests-slyk-pvc-6d5a76
ff-bbee-418e-8e24-7515597422e3 gke-substra-tests-slyk-pvc-7802f2e8-9b9a-412a-9533-b1514766acfe gke-substra-tests-slyk-pvc-8c88102f-ceb2-4825-9e5b-e1c8058e0418 gke-substra-tests-slyk-pvc-97997789-ee1b-419d-a66d-040b46d2ec5d gke-substra-tes
ts-slyk-pvc-aea0f730-28b5-498d-8a58-651131ba3504 gke-substra-tests-slyk-pvc-bc30a525-bb15-421b-90c0-6f15328cbc60 gke-substra-tests-slyk-pvc-c0ce633e-bef2-4522-80e6-5c37d957ad85 gke-substra-tests-slyk-pvc-c224d8d3-c311-4bde-9f3a-95b3fe5eb0
a4 gke-substra-tests-slyk-pvc-cea49df7-100c-4d7d-bcb9-488f90b8a01b gke-substra-tests-slyk-pvc-dd908d0d-767a-4392-91f2-06a759a40c76 gke-substra-tests-slyk-pvc-df3e2b4c-923a-4cb3-87c6-3382fa1a9730 gke-substra-tests-slyk-pvc-e2d7ba5e-b131-45
07-b551-041ac09a7a79 gke-substra-tests-slyk-pvc-e755813b-7d85-415e-83ec-0a3d73d47b2e']' returned non-zero exit status 1.
```
## Changes include
- [x] Add `zones:(ZONE)` filtering for `gcloud compute disks list`
- [x] Add `--zone ZONE` option for `gcloud compute disks delete`

## Checklist
- [x] I have tested this code

## Other comments

More information can be found in the gcloud cli documentation : 
 - https://cloud.google.com/sdk/gcloud/reference/compute/disks/list
 - https://cloud.google.com/sdk/gcloud/reference/compute/disks/delete