### PR TITLE
Add '--project' flag to avoid project value issue in Travis

### DIFF
--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -251,11 +251,12 @@ def delete_cluster():
 def delete_disks():
     try:
         filter = f'name~^gke-{PVC_VOLUME_NAME_PREFIX}-pvc-.* AND -users:* AND -zones:({CLUSTER_ZONE})'
-        cmd = f'gcloud compute disks list --format="table(name)" --filter="{filter}" | sed 1d'
+        cmd = f'gcloud compute disks list --project {CLUSTER_PROJECT} --format="table(name)" --filter="{filter}" '\
+              '| sed 1d'
         disks = call_output(cmd)
         disks = disks.replace("\n", " ")
         if disks:
-            call(f'gcloud compute disks delete --zone {CLUSTER_ZONE} --quiet {disks}')
+            call(f'gcloud compute disks delete --zone {CLUSTER_ZONE} --project {CLUSTER_PROJECT} --quiet {disks}')
     except Exception as ex:
         print('ERROR: Deletion of the GCP disks failed', ex)
 


### PR DESCRIPTION
## Description
It looks like `gcloud` cli response on `compute disks list/delete` put the light on the need to use `--project` flag to be able to list and delete disks in a Travis job.
I added in the PR the flag for `compute disks list` and `compute disks delete` 

## Closes issue(s)
None
## Companion PRs
None

## How to test / repro

You can repro it by launching the Travis CI with e2e remote tests on master branch but it's not automatic.

## Screenshots / Trace
```shell
+ gcloud compute disks delete --zone europe-west4-a --quiet ERROR: (gcloud.compute.disks.list) Some requests did not succeed:  - Required 'compute.disks.list' permission for 'projects/travis-ci-prod-oss-4'
/bin/sh: 1: Syntax error: "(" unexpected
ERROR: Deletion of the GCP disks failed Command '["gcloud compute disks delete --zone europe-west4-a --quiet ERROR: (gcloud.compute.disks.list) Some requests did not succeed:  - Required 'compute.disks.list' permission for 'projects/travis-ci-prod-oss-4'"]' returned non-zero exit status 2.
```

https://travis-ci.org/github/SubstraFoundation/substra-tests/jobs/744561959#L992-L994

## Changes include
- [x] Add `--project PROJECT` flag for `gcloud compute disks list`
- [x] Add `--project PROJECT` flag for `gcloud compute disks delete`

## Checklist
- [x] I have tested this code

## Other comments

More information can be found in the gcloud cli documentation, under **GCLOUD WIDE FLAGS** section : 
 - https://cloud.google.com/sdk/gcloud/reference/compute/disks/list
 - https://cloud.google.com/sdk/gcloud/reference/compute/disks/delete