### PR TITLE
Update run-ci.py with new chaincode structure

### DIFF
--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -44,6 +44,7 @@ import argparse
 import subprocess
 import sys
 import yaml
+import logging
 
 CLUSTER_NAME_ALLOWED_PREFIX = 'substra-tests'
 CLUSTER_NAME = ''
@@ -550,12 +551,10 @@ def patch_values_file(config, value_file):
     if config['name'] == 'substra-backend':
         data['celeryworker']['concurrency'] = BACKEND_CELERY_CONCURRENCY
     if config['name'] == 'hlf-k8s':
-        if 'appChannels' in data:
-            for i in range(len(data['appChannels'])):
-                if 'chaincodes' in data['appChannels'][i]:
-                    data['appChannels'][i]['chaincodes'][0]['image']['repository'] = \
-                        f'eu.gcr.io/{CLUSTER_PROJECT}/substra-chaincode'
-                    data['appChannels'][i]['chaincodes'][0]['image']['tag'] = f'ci-{CHAINCODE_COMMIT}'
+        if 'chaincodes' in data:
+            data['chaincodes'][0]['image']['repository'] = \
+                f'eu.gcr.io/{CLUSTER_PROJECT}/substra-chaincode'
+            data['chaincodes'][0]['image']['tag'] = f'ci-{CHAINCODE_COMMIT}'
 
     with open(value_file, 'w') as file:
         yaml.dump(data, file)
@@ -606,6 +605,7 @@ def main():
 
     except Exception as e:
         print(f'FATAL: {e}')
+        logging.exception(e)
         is_success = False
 
     finally:


### PR DESCRIPTION
## Description
In order to be compatible with https://github.com/SubstraFoundation/hlf-k8s/pull/102 we need to update run-ci.py patch function to handle new chaincode value structure for deployment.

## Closes issue(s)
None

## Companion PRs
https://github.com/SubstraFoundation/hlf-k8s/pull/102

## How to test / repro
`./ci/run-ci.py --substra-chaincode add-channel-log --substra-backend speed-up-download --substra-tests share-chaincode --hlf-k8s channels-share-chaincode`

## Screenshots / Trace
```
FATAL: 'image'
ERROR:root:'image'
Traceback (most recent call last):
  File "/Users/kmoutet/Substra/substra-tests/./ci/run-ci.py", line 603, in main
    deploy_all(configs)
  File "/Users/kmoutet/Substra/substra-tests/./ci/run-ci.py", line 482, in deploy_all
    deploy(config, wait)
  File "/Users/kmoutet/Substra/substra-tests/./ci/run-ci.py", line 487, in deploy
    skaffold_file = patch_skaffold_file(config)
  File "/Users/kmoutet/Substra/substra-tests/./ci/run-ci.py", line 543, in patch_skaffold_file
    patch_values_file(config, os.path.join(SOURCE_DIR, config['name'], values_file))
  File "/Users/kmoutet/Substra/substra-tests/./ci/run-ci.py", line 557, in patch_values_file
    data['appChannels'][i]['chaincodes'][0]['image']['repository'] = \
KeyError: 'image'
```
## Changes include
- [x] Update run-ci.py with new chaincode value structure for deployment
- [x] Add logging exception in the main function of run-ci.py

## Checklist
- [x] I have tested this code

## Other comments
None