### PR TITLE
Update test following bugfix - debug mode - aggregate tuple took the head model 

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -380,11 +380,7 @@ def test_aggregate_composite_traintuples(factory, network, clients, default_data
         )
         testtuple = clients[0].add_testtuple(spec)
         testtuple = clients[0].wait(testtuple)
-        if clients[0].debug:
-            assert testtuple.dataset.perf == 30
-        else:
-            # There is only one dataset in 'datasets' in local, hence the difference
-            assert testtuple.dataset.perf == 32
+        assert testtuple.dataset.perf == 32
 
     if not network.options.enable_intermediate_model_removal:
         return


### PR DESCRIPTION
Debug mode - the aggregate tuple took the head model instead of the trunk model of the in composite traintuple and the test result reflected that