### PR TITLE
Fix Lint issues

### DIFF
--- a/substratest/factory.py
+++ b/substratest/factory.py
@@ -1,7 +1,6 @@
 import abc
 import os
 import pathlib
-import random
 import shutil
 import tempfile
 import typing
@@ -11,7 +10,7 @@ import uuid
 import pydantic
 
 from substra.sdk import models
-from . import utils, assets
+from . import utils, assets # noqa F401
 
 
 DEFAULT_DATA_SAMPLE_FILENAME = 'data.csv'
@@ -62,7 +61,7 @@ class TestOpener(tools.Opener):
             return json.dump(y_pred, f)
 """
 
-DEFAULT_METRICS_SCRIPT = f"""
+DEFAULT_METRICS_SCRIPT = """
 import json
 import substratools as tools
 class TestMetrics(tools.Metrics):
@@ -74,7 +73,7 @@ if __name__ == '__main__':
     tools.metrics.execute(TestMetrics())
 """
 
-DEFAULT_ALGO_SCRIPT = f"""
+DEFAULT_ALGO_SCRIPT = """
 import json
 import substratools as tools
 class TestAlgo(tools.Algo):
@@ -111,7 +110,7 @@ if __name__ == '__main__':
     tools.algo.execute(TestAlgo())
 """
 
-DEFAULT_AGGREGATE_ALGO_SCRIPT = f"""
+DEFAULT_AGGREGATE_ALGO_SCRIPT = """
 import json
 import substratools as tools
 class TestAggregateAlgo(tools.AggregateAlgo):
@@ -134,7 +133,7 @@ if __name__ == '__main__':
 
 # TODO we should have a different serializer for head and trunk models
 
-DEFAULT_COMPOSITE_ALGO_SCRIPT = f"""
+DEFAULT_COMPOSITE_ALGO_SCRIPT = """
 import json
 import substratools as tools
 class TestCompositeAlgo(tools.CompositeAlgo):
@@ -245,6 +244,7 @@ class PrivatePermissions(pydantic.BaseModel):
 DEFAULT_PERMISSIONS = Permissions(public=True, authorized_ids=[])
 DEFAULT_OUT_TRUNK_MODEL_PERMISSIONS = PrivatePermissions(authorized_ids=[])
 SERVER_MEDIA_PATH = '/var/substra/servermedias/'
+
 
 class DataSampleSpec(_Spec):
     path: str

--- a/substratest/utils.py
+++ b/substratest/utils.py
@@ -21,4 +21,3 @@ def create_archive(tmpdir, *files):
         with open(tmpdir / path, 'w') as f:
             f.write(content)
     return zip_folder(str(tmpdir))
-

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,7 +1,6 @@
 import pytest
 
 from substra.sdk import models
-from substratest import assets
 from substratest.factory import Permissions
 
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -6,8 +6,6 @@ from substra.sdk.models import Status
 import substratest as sbt
 from substratest.factory import Permissions
 
-from substratest import assets
-
 
 @pytest.mark.slow
 def test_tuples_execution_on_same_node(factory, client, default_dataset, default_objective):

--- a/tests/test_execution_compute_plan.py
+++ b/tests/test_execution_compute_plan.py
@@ -4,8 +4,6 @@ from substra.sdk import models
 import substratest as sbt
 from substratest.factory import Permissions
 
-from substratest import assets
-
 
 @pytest.mark.remote_only
 def test_compute_plan(factory, client_1, client_2, default_dataset_1, default_dataset_2, default_objective_1):
@@ -391,6 +389,7 @@ def test_compute_plan_aggregate_composite_traintuples(factory, clients, default_
     # Check that permissions were correctly set
     for tuple in composite_traintuples:
         assert len(tuple.out_trunk_model.permissions.process.authorized_ids) == len(clients)
+
 
 @pytest.mark.slow
 @pytest.mark.remote_only

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -41,7 +41,7 @@ def test_describe_dataset(factory, client):
 
 def test_add_duplicate_dataset(factory, client):
     spec = factory.create_dataset()
-    dataset = client.add_dataset(spec)
+    client.add_dataset(spec)
 
     # does not raise
     client.add_dataset(spec)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -2,10 +2,7 @@ import substra
 
 import pytest
 
-from substra.sdk import models
-
 from substratest.factory import Permissions
-from substratest import assets
 from . import settings
 
 MSP_IDS = settings.MSP_IDS


### PR DESCRIPTION
## Description

Fixes the flake8 errors that were showing up on the repo.

## Motivation and Context

I added flake8 as a part of the CI in this PR https://github.com/SubstraFoundation/substra-tests/pull/170 and we will not be able to merge it until the lint is showing nothing.

## Screenshots (if appropriate):

Failing lints:
<img width="1025" alt="Screenshot 2020-12-17 at 14 33 29" src="https://user-images.githubusercontent.com/17547702/102494390-dfcbee00-4074-11eb-94b5-8700da4b152b.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)