### PR TITLE
Increase substra-tests skaffold status check deadline value

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -24,6 +24,7 @@ build:
           SUBSTRA_GIT_REPO: https://github.com/SubstraFoundation/substra.git
           SUBSTRA_GIT_REF: master
 deploy:
+  statusCheckDeadlineSeconds: 300
   helm:
     releases:
       - name: substra-tests


### PR DESCRIPTION
## Description
E2E CI tests regularly fail because of substra-tests pod deployment stabilization (see trace).
We increase the value of `statusCheckDeadlineSeconds` from `120s` (default) to `300s`

## Closes issue(s)
None

## Companion PRs
None

## How to test / repro
Run `python ci/run-ci.py --substra-tests increase-status-check-deadline`

## Screenshots / Trace
```
Waiting for deployments to stabilize...
 - substra-tests:deployment/substra-tests: waiting for rollout to finish: 0 of 1 updated replicas are available...
 - substra-tests:deployment/substra-tests: could not stabilize within 2m0s
 - substra-tests:deployment/substra-tests failed. Error: could not stabilize within 2m0s.
1/1 deployment(s) failed
FATAL: Command '['cd /home/travis/build/SubstraFoundation/substra-tests/ci/src/3UQlGHmusX/substra-tests && skaffold deploy --kube-context=gke_substra-208412_europe-west4-a_substra-tests-2021-01-05-01h57-3uqlghmus -f=skaffold.yaml -a=/home/travis/build/SubstraFoundation/substra-tests/ci/src/3UQlGHmusX/substra-tests/tags.json --status-check=true']' returned non-zero exit status 1.
ERROR:root:Command '['cd /home/travis/build/SubstraFoundation/substra-tests/ci/src/3UQlGHmusX/substra-tests && skaffold deploy --kube-context=gke_substra-208412_europe-west4-a_substra-tests-2021-01-05-01h57-3uqlghmus -f=skaffold.yaml -a=/home/travis/build/SubstraFoundation/substra-tests/ci/src/3UQlGHmusX/substra-tests/tags.json --status-check=true']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "./run-ci.py", line 601, in main
    deploy_all(configs)
  File "./run-ci.py", line 482, in deploy_all
    deploy(config, wait)
  File "./run-ci.py", line 494, in deploy
    call(f'cd {path} && skaffold deploy --kube-context={KUBE_CONTEXT} '
  File "./run-ci.py", line 90, in call
    return subprocess.check_call([cmd], shell=True)
  File "/opt/python/3.7.1/lib/python3.7/subprocess.py", line 341, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cd /home/travis/build/SubstraFoundation/substra-tests/ci/src/3UQlGHmusX/substra-tests && skaffold deploy --kube-context=gke_substra-208412_europe-west4-a_substra-tests-2021-01-05-01h57-3uqlghmus -f=skaffold.yaml -a=/home/travis/build/SubstraFoundation/substra-tests/ci/src/3UQlGHmusX/substra-tests/tags.json --status-check=true']' returned non-zero exit status 1.
```

## Changes include
- [x] Bugfix (non-breaking change that solves an issue)

## Checklist
- [x] I have tested this code

## Other comments
None
