### PR TITLE
Fix CI cluster name and filter disks

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -35,7 +35,8 @@ jobs:
         run: gpg --quiet --batch --yes --decrypt --passphrase="$SECRET_KEY" --output ci/keys/substra-208412-3be0df12d87a.json ci/keys/substra-208412-3be0df12d87a.json.gpg
       - name: Test
         run: |
-          CLUSTER_NAME="substra-tests-$(date -u +'%Y-%m-%d-%Hh%M')"
+          RANDOM_ID=$(LC_CTYPE=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
+          CLUSTER_NAME="substra-tests-${RANDOM_ID}-$(date -u +'%Y-%m-%d-%Hh%M')"
           cd ci/
           python -u ./run-ci.py --keys-directory=./keys/ --cluster-name=${CLUSTER_NAME}
       - name: Slack Notification

--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -251,7 +251,7 @@ def delete_cluster():
 
 def delete_disks():
     try:
-        filter = f'name~^gke-{PVC_VOLUME_NAME_PREFIX}-pvc-.* AND -users:* AND -zones:({CLUSTER_ZONE})'
+        filter = f'name~^gke-{PVC_VOLUME_NAME_PREFIX}-pvc-.* users~.* zone~{CLUSTER_ZONE}'  # the filter AND is implicit
         cmd = f'gcloud compute disks list --project {CLUSTER_PROJECT} --format="table(name)" --filter="{filter}" '\
               '| sed 1d'
         disks = call_output(cmd)


### PR DESCRIPTION
Fix CI e2e tests by :
- Adding random id in the CI name as gcp use the 18 first chars to name disks
- Fix warning on list gcp disks