### PR TITLE
fix: harmonize chart url by removing  extra '/'

### DIFF
--- a/ci/run-ci.py
+++ b/ci/run-ci.py
@@ -291,7 +291,7 @@ def wait_for_cluster():
 def setup_helm():
     print('\n# Setup Helm')
     call('helm repo add stable https://charts.helm.sh/stable')
-    call('helm repo add owkin https://owkin.github.io/charts/')
+    call('helm repo add owkin https://owkin.github.io/charts')
     call('helm repo add bitnami https://charts.bitnami.com/bitnami')
 
 


### PR DESCRIPTION
You may have to do a `helm repo rm` on conflicting chart (here owkin :) )
