### PR TITLE
chore: ignore timestamps in zipfile

### DIFF
--- a/substratest/utils.py
+++ b/substratest/utils.py
@@ -11,7 +11,10 @@ def zip_folder(path, destination=None):
             for f in files:
                 abspath = os.path.join(root, f)
                 archive_path = os.path.relpath(abspath, start=path)
-                zf.write(abspath, arcname=archive_path)
+                info = zipfile.ZipInfo.from_file(abspath, arcname=archive_path)
+                info.date_time = (1980, 1, 1, 0, 0, 0)
+                with open(abspath) as src:
+                    zf.writestr(info, src.read())
     return destination
 
 


### PR DESCRIPTION
Background: By defaut, zip files include timestamps of the files contained in the archive. As a result, two zip files can be identical in terms of their content, but differ in their checksum because the content timestamps are different.

Remove file timestamps from the zip archive, so that two zip files with the same contents have the same checksum. This can be helpful in local/debug scenarios: in the backend use the algo checksum as the image name, disable image deletion, then run a test => kaniko builds are ran once then skipped.